### PR TITLE
Start v2 development

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Use Node.js
       uses: actions/setup-node@v2
       with:
-        node-version: '14'
+        node-version: '16'
     - name: Install pnpm
       run: npm i -g pnpm
     - name: Install dependencies

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,7 +4,6 @@ export default {
   collectCoverageFrom: [
     'src/**/*.ts',
     '!src/**/*.spec.ts',
-    '!src/**/index.ts',
     '!**/node_modules/**',
   ],
   coverageDirectory: 'target/coverage',
@@ -17,6 +16,15 @@ export default {
     },
   },
   extensionsToTreatAsEsm: ['.ts'],
+  globals: {
+    'ts-jest': {
+      tsconfig: 'tsconfig.spec.json',
+      useESM: true,
+    },
+  },
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
   reporters: [
     'default',
     [
@@ -32,10 +40,4 @@ export default {
     ],
   ],
   testEnvironment: 'node',
-  globals: {
-    'ts-jest': {
-      tsconfig: 'tsconfig.spec.json',
-      useESM: true,
-    },
-  },
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proc7ts/supply",
-  "version": "1.2.3",
+  "version": "2.0.0-pre.0",
   "description": "The supply of something",
   "keywords": [
     "subscription"

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -6,7 +6,7 @@ import typescript from 'typescript';
 
 export default defineConfig({
   input: {
-    supply: './src/index.ts',
+    supply: './src/mod.ts',
   },
   plugins: [
     ts({

--- a/src/always-supply.spec.ts
+++ b/src/always-supply.spec.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, jest } from '@jest/globals';
-import { alwaysSupply, isAlwaysSupply } from './always-supply';
-import { neverSupply } from './never-supply';
-import { Supply } from './supply';
+import { alwaysSupply, isAlwaysSupply } from './always-supply.js';
+import { neverSupply } from './never-supply.js';
+import { Supply } from './supply.js';
 
 describe('alwaysSupply', () => {
   afterEach(() => {

--- a/src/always-supply.ts
+++ b/src/always-supply.ts
@@ -1,5 +1,5 @@
-import { Supply } from './supply';
-import type { SupplyPeer } from './supply-peer';
+import type { SupplyPeer } from './supply-peer.js';
+import { Supply } from './supply.js';
 
 class AlwaysSupply extends Supply {
 

--- a/src/impl/cb-0.state.ts
+++ b/src/impl/cb-0.state.ts
@@ -1,12 +1,11 @@
-import type { Supply } from '../supply.js';
 import { SupplyState$Cb1 } from './cb-1.state.js';
 import { Supply$off$unexpected, SupplyState$On } from './on.state.js';
-import { SupplyState__symbol } from './state.js';
+import type { SupplyState } from './state.js';
 
 class SupplyState$Cb0 extends SupplyState$On {
 
-  whenOff(supply: Supply, callback: (reason?: unknown) => void): void {
-    supply[SupplyState__symbol] = new SupplyState$Cb1(callback);
+  whenOff(update: (supply: SupplyState) => void, callback: (reason?: unknown) => void): void {
+    update(new SupplyState$Cb1(callback));
   }
 
   protected override cb(reason: unknown): void {

--- a/src/impl/cb-0.state.ts
+++ b/src/impl/cb-0.state.ts
@@ -1,7 +1,7 @@
-import type { Supply } from '../supply';
-import { SupplyState$Cb1 } from './cb-1.state';
-import { Supply$off$unexpected, SupplyState$On } from './on.state';
-import { SupplyState__symbol } from './state';
+import type { Supply } from '../supply.js';
+import { SupplyState$Cb1 } from './cb-1.state.js';
+import { Supply$off$unexpected, SupplyState$On } from './on.state.js';
+import { SupplyState__symbol } from './state.js';
 
 class SupplyState$Cb0 extends SupplyState$On {
 

--- a/src/impl/cb-1.state.ts
+++ b/src/impl/cb-1.state.ts
@@ -1,16 +1,22 @@
-import type { Supply } from '../supply.js';
 import { SupplyState$CbN } from './cb-n.state.js';
 import { SupplyState$On } from './on.state.js';
-import { SupplyState__symbol } from './state.js';
+import { SupplyState } from './state.js';
 
 export class SupplyState$Cb1 extends SupplyState$On {
 
-  constructor(protected readonly cb: (this: void, reason?: unknown) => void) {
+  readonly #cb: (this: void, reason?: unknown) => void;
+
+  constructor(cb: (this: void, reason?: unknown) => void) {
     super();
+    this.#cb = cb;
   }
 
-  whenOff(supply: Supply, callback: (reason?: unknown) => void): void {
-    supply[SupplyState__symbol] = new SupplyState$CbN([this.cb, callback]);
+  whenOff(update: (supply: SupplyState) => void, callback: (reason?: unknown) => void): void {
+    update(new SupplyState$CbN([this.#cb, callback]));
+  }
+
+  protected override cb(reason: unknown): void {
+    this.#cb(reason);
   }
 
 }

--- a/src/impl/cb-1.state.ts
+++ b/src/impl/cb-1.state.ts
@@ -1,7 +1,7 @@
-import type { Supply } from '../supply';
-import { SupplyState$CbN } from './cb-n.state';
-import { SupplyState$On } from './on.state';
-import { SupplyState__symbol } from './state';
+import type { Supply } from '../supply.js';
+import { SupplyState$CbN } from './cb-n.state.js';
+import { SupplyState$On } from './on.state.js';
+import { SupplyState__symbol } from './state.js';
 
 export class SupplyState$Cb1 extends SupplyState$On {
 

--- a/src/impl/cb-n.state.ts
+++ b/src/impl/cb-n.state.ts
@@ -1,5 +1,5 @@
-import type { Supply } from '../supply';
-import { SupplyState$On } from './on.state';
+import type { Supply } from '../supply.js';
+import { SupplyState$On } from './on.state.js';
 
 export class SupplyState$CbN extends SupplyState$On {
 

--- a/src/impl/cb-n.state.ts
+++ b/src/impl/cb-n.state.ts
@@ -1,18 +1,20 @@
-import type { Supply } from '../supply.js';
 import { SupplyState$On } from './on.state.js';
 
 export class SupplyState$CbN extends SupplyState$On {
 
-  constructor(private readonly cbs: ((this: void, reason?: unknown) => void)[]) {
+  readonly #cbs: ((this: void, reason?: unknown) => void)[];
+
+  constructor(cbs: ((this: void, reason?: unknown) => void)[]) {
     super();
+    this.#cbs = cbs;
   }
 
-  whenOff(_supply: Supply, callback: (reason?: unknown) => void): void {
-    this.cbs.push(callback);
+  whenOff(_update: unknown, callback: (reason?: unknown) => void): void {
+    this.#cbs.push(callback);
   }
 
   protected override cb(reason: unknown): void {
-    for (const cb of this.cbs) {
+    for (const cb of this.#cbs) {
       cb(reason);
     }
   }

--- a/src/impl/index.ts
+++ b/src/impl/index.ts
@@ -1,5 +1,0 @@
-export * from './cb-0.state';
-export * from './cb-1.state';
-export * from './off.state';
-export * from './state';
-export * from './unexpected-abort';

--- a/src/impl/mod.ts
+++ b/src/impl/mod.ts
@@ -1,0 +1,5 @@
+export * from './cb-0.state.js';
+export * from './cb-1.state.js';
+export * from './off.state.js';
+export * from './state.js';
+export * from './unexpected-abort.js';

--- a/src/impl/off.state.ts
+++ b/src/impl/off.state.ts
@@ -1,5 +1,5 @@
-import type { Supply } from '../supply';
-import type { SupplyState } from './state';
+import type { Supply } from '../supply.js';
+import type { SupplyState } from './state.js';
 
 class SupplyState$Off implements SupplyState {
 

--- a/src/impl/off.state.ts
+++ b/src/impl/off.state.ts
@@ -1,21 +1,23 @@
-import type { Supply } from '../supply.js';
 import type { SupplyState } from './state.js';
 
 class SupplyState$Off implements SupplyState {
 
-  constructor(private readonly reason: unknown) {
+  readonly #reason: unknown;
+
+  constructor(reason: unknown) {
+    this.#reason = reason;
   }
 
   get isOff(): true {
     return true;
   }
 
-  off(_supply: Supply, _reason?: unknown): void {
+  off(_update: unknown, _reason?: unknown): void {
     // Already off.
   }
 
-  whenOff(_supply: Supply, callback: (reason?: unknown) => void): void {
-    callback(this.reason);
+  whenOff(_update: unknown, callback: (reason?: unknown) => void): void {
+    callback(this.#reason);
   }
 
 }

--- a/src/impl/on.state.ts
+++ b/src/impl/on.state.ts
@@ -1,8 +1,8 @@
-import type { Supply } from '../supply';
-import { SupplyState$off } from './off.state';
-import type { SupplyState } from './state';
-import { SupplyState__symbol } from './state';
-import { Supply$unexpectedAbort } from './unexpected-abort';
+import type { Supply } from '../supply.js';
+import { SupplyState$off } from './off.state.js';
+import type { SupplyState } from './state.js';
+import { SupplyState__symbol } from './state.js';
+import { Supply$unexpectedAbort } from './unexpected-abort.js';
 
 let Supply$off: 0 | 1 = 0;
 let Supply$off$unexpected$reasons: Set<unknown> | undefined;

--- a/src/impl/on.state.ts
+++ b/src/impl/on.state.ts
@@ -1,7 +1,5 @@
-import type { Supply } from '../supply.js';
 import { SupplyState$off } from './off.state.js';
 import type { SupplyState } from './state.js';
-import { SupplyState__symbol } from './state.js';
 import { Supply$unexpectedAbort } from './unexpected-abort.js';
 
 let Supply$off: 0 | 1 = 0;
@@ -13,8 +11,8 @@ export abstract class SupplyState$On implements SupplyState {
     return false;
   }
 
-  off(supply: Supply, reason?: unknown): void {
-    supply[SupplyState__symbol] = SupplyState$off(reason);
+  off(update: (supply: SupplyState) => void, reason?: unknown): void {
+    update(SupplyState$off(reason));
     if (Supply$off) {
       this.cb(reason);
     } else {
@@ -28,7 +26,7 @@ export abstract class SupplyState$On implements SupplyState {
     }
   }
 
-  abstract whenOff(supply: Supply, callback: (reason?: unknown) => void): void;
+  abstract whenOff(update: (supply: SupplyState) => void, callback: (reason?: unknown) => void): void;
 
   protected abstract cb(reason: unknown): void;
 

--- a/src/impl/state.ts
+++ b/src/impl/state.ts
@@ -1,13 +1,9 @@
-import type { Supply } from '../supply.js';
-
-export const SupplyState__symbol = (/* #__PUR E__ */ Symbol('SupplyState'));
-
 export interface SupplyState {
 
   readonly isOff: boolean;
 
-  off(supply: Supply, reason?: unknown): void;
+  off(update: (supply: SupplyState) => void, reason?: unknown): void;
 
-  whenOff(supply: Supply, callback: (reason?: unknown) => void): void;
+  whenOff(update: (supply: SupplyState) => void, callback: (reason?: unknown) => void): void;
 
 }

--- a/src/impl/state.ts
+++ b/src/impl/state.ts
@@ -1,6 +1,6 @@
-import type { Supply } from '../supply';
+import type { Supply } from '../supply.js';
 
-export const SupplyState__symbol = (/*#__PURE__*/ Symbol('SupplyState'));
+export const SupplyState__symbol = (/* #__PUR E__ */ Symbol('SupplyState'));
 
 export interface SupplyState {
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,0 @@
-/**
- * @packageDocumentation
- * @module @proc7ts/supply
- */
-export * from './always-supply';
-export * from './never-supply';
-export * from './supply';
-export * from './supply-peer';

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -1,0 +1,8 @@
+/**
+ * @packageDocumentation
+ * @module @proc7ts/supply
+ */
+export * from './always-supply.js';
+export * from './never-supply.js';
+export * from './supply.js';
+export * from './supply-peer.js';

--- a/src/never-supply.spec.ts
+++ b/src/never-supply.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, jest } from '@jest/globals';
-import { neverSupply } from './never-supply';
-import { Supply } from './supply';
+import { neverSupply } from './never-supply.js';
+import { Supply } from './supply.js';
 
 describe('neverSupply', () => {
   describe('isOff', () => {

--- a/src/never-supply.ts
+++ b/src/never-supply.ts
@@ -1,5 +1,5 @@
-import { Supply } from './supply';
-import type { SupplyPeer } from './supply-peer';
+import type { SupplyPeer } from './supply-peer.js';
+import { Supply } from './supply.js';
 
 class NeverSupply extends Supply {
 

--- a/src/supply-peer.ts
+++ b/src/supply-peer.ts
@@ -1,4 +1,4 @@
-import type { Supply } from './supply';
+import type { Supply } from './supply.js';
 
 /**
  * A peer of supply, i.e. a supply participant. E.g. supplier or consumer.

--- a/src/supply.spec.ts
+++ b/src/supply.spec.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import type { Mock, SpyInstance } from 'jest-mock';
-import { Supply } from './supply';
+import { Supply } from './supply.js';
 
 describe('Supply', () => {
 

--- a/src/supply.ts
+++ b/src/supply.ts
@@ -1,5 +1,5 @@
 import type { SupplyState } from './impl/mod.js';
-import { Supply$unexpectedAbort$handle, SupplyState$cb0, SupplyState$Cb1, SupplyState__symbol } from './impl/mod.js';
+import { Supply$unexpectedAbort$handle, SupplyState$cb0, SupplyState$Cb1 } from './impl/mod.js';
 import type { SupplyPeer } from './supply-peer';
 
 /**
@@ -25,10 +25,8 @@ export class Supply implements SupplyPeer {
     Supply$unexpectedAbort$handle(handler);
   }
 
-  /**
-   * @internal
-   */
-  [SupplyState__symbol]: SupplyState;
+  #state: SupplyState;
+  readonly #update = (state: SupplyState): void => { this.#state = state; };
 
   /**
    * Constructs new supply instance.
@@ -37,7 +35,7 @@ export class Supply implements SupplyPeer {
    * as its only parameter. No-op by default.
    */
   constructor(off?: (this: void, reason?: unknown) => void) {
-    this[SupplyState__symbol] = off ? new SupplyState$Cb1(off) : SupplyState$cb0;
+    this.#state = off ? new SupplyState$Cb1(off) : SupplyState$cb0;
   }
 
   /**
@@ -50,16 +48,16 @@ export class Supply implements SupplyPeer {
   /**
    * Whether this supply is {@link off cut off} already.
    *
-   * `true` means nothing would be supplied any more.
+   * `true` means nothing would be supplied anymore.
    */
   get isOff(): boolean {
-    return this[SupplyState__symbol].isOff;
+    return this.#state.isOff;
   }
 
   /**
    * Cuts off this supply.
    *
-   * After this method call nothing would be supplied any more.
+   * After this method call nothing would be supplied anymore.
    *
    * Calling this method for the second time has no effect.
    *
@@ -69,7 +67,7 @@ export class Supply implements SupplyPeer {
    * @returns The cut off supply instance.
    */
   off(reason?: unknown): Supply {
-    this[SupplyState__symbol].off(this, reason);
+    this.#state.off(this.#update, reason);
 
     return this;
   }
@@ -84,7 +82,7 @@ export class Supply implements SupplyPeer {
    * @returns `this` instance.
    */
   whenOff(callback: (this: void, reason?: unknown) => void): this {
-    this[SupplyState__symbol].whenOff(this, callback);
+    this.#state.whenOff(this.#update, callback);
 
     return this;
   }

--- a/src/supply.ts
+++ b/src/supply.ts
@@ -1,5 +1,5 @@
-import type { SupplyState } from './impl';
-import { Supply$unexpectedAbort$handle, SupplyState$cb0, SupplyState$Cb1, SupplyState__symbol } from './impl';
+import type { SupplyState } from './impl/mod.js';
+import { Supply$unexpectedAbort$handle, SupplyState$cb0, SupplyState$Cb1, SupplyState__symbol } from './impl/mod.js';
 import type { SupplyPeer } from './supply-peer';
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,6 @@
     "noUnusedParameters": true,
     "forceConsistentCasingInFileNames": true,
     "importHelpers": true,
-    "importsNotUsedAsValues": "error",
     "noEmitHelpers": true,
     "lib": ["DOM", "ES2022"],
     "types": [],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "moduleResolution": "Node",
     "module": "ES2015",
-    "target": "ES2019",
+    "target": "ES2022",
     "strict": true,
     "noFallthroughCasesInSwitch": true,
     "noImplicitOverride": true,
@@ -13,7 +13,7 @@
     "importHelpers": true,
     "importsNotUsedAsValues": "error",
     "noEmitHelpers": true,
-    "lib": ["DOM", "ES2019"],
+    "lib": ["DOM", "ES2022"],
     "types": [],
     "outDir": "target/js",
     "sourceMap": true,

--- a/tsconfig.main.json
+++ b/tsconfig.main.json
@@ -1,5 +1,5 @@
 {
   "extends": "./tsconfig.json",
-  "files": ["./src/index.ts"],
+  "files": ["./src/mod.ts"],
   "include": []
 }

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,5 +1,5 @@
 {
-  "entryPoints": ["src/index.ts"],
+  "entryPoints": ["src/mod.ts"],
   "name": "Supply",
   "out": "./target/typedoc",
   "tsconfig": "tsconfig.main.json"


### PR DESCRIPTION
- Start v2 development
- Add `.js` extensions to relative imports
- Use private members
