### PR TITLE
Indicate supply cut off with `SupplyIsOff` indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,28 +77,16 @@ When called, all registered cut off callbacks are called with the given reason a
 
 [isoff]: #isoff
 
-This is a flag indicating whether the supply is cut off.
+Indicates whether this supply is [cut off] already.
 
-Equals to `false` initially. Becomes `true` after calling the [off()] method.
+`undefined` initially. Set once supply [cut off]. Once set, nothing will be supplied anymore.
 
-### `whyOff`
+The value returned is an object that indicates why the supply has been cut off (i.e. due to failure or successful
+completion), and when this happened.
 
-[whyoff]: #whyoff
+### `alsoOff(receiver: { isOff: undefined, off: (reason?: unknown) => void })`
 
-The reason why supply is cut off. `undefined` while the supply is not cut off.
-
-### `whenOff(callback: (reason?: unknown) => void)`
-
-Registers a callback function that will be called when the supply is [cut off]. If the supply is cut off already when
-calling this method, the callback will be called immediately.
-
-The registered callback receives a cutoff reason as its only parameter.
-
-The callback will be called at most once.
-
-### `alsoOff(receiver: { isOff: false, off: (reason?: unknown) => void })`
-
-[alsooff]: #alsooffreceiver--isoff-false-off-reason-unknown--void-
+[alsooff]: #alsooffreceiver--isoff-undefined-off-reason-unknown--void-
 
 Registers a receiver of the supply.
 
@@ -110,12 +98,18 @@ Supply receivers may be used as a passive alternative to `removeEventListener` a
 to remove the listener in order to stop receiving events, the supply receiver may set itself unavailable, so that the
 supplier would be able to remove it occasionally.
 
+### `whenOff(receiver: (reason?: unknown) => void)`
+
+Registers a supply receiver function that will be called as soon as this supply [cut off].
+
+Calling this method is the same as calling `this.alsoOff(SupplyReceiver(receiver))`
+
 ### `whenDone()`
 
-Returns a promise that will be resolved once the supply is [cut off].
+Builds a promise that will be resolved once the supply is [cut off].
 
-The returned promise will be successfully resolved once the supply is cut off without a reason, or rejected once the
-supply is cut off with any reason except `undefined`.
+The returned promise will be successfully resolved once this supply completes successfully, or rejected with failure
+reason.
 
 ### `derive(derived?: SupplyReceiver)`
 
@@ -172,9 +166,10 @@ Creates a supply, that is automatically cut off after specified `timeout`.
 Optional `createReason` function creates a custom reason why the supply cut off after timeout. A timeout error used
 as reason when omitted.
 
-# Unexpected Aborts
+# Unexpected Failures
 
-An unexpected abort happens when any supply [cut off] with some reason, but there is no cut off callback registered.
+Unexpected failure happens when any supply [cut off] due to some failure, and there is no supply receiver registered
+and still available to handle it.
 
-By default, an unexpected abort reason is logged to console. This behavior can be changed by assigning another
-unexpected abort handler with `Supply.onUnexpectedAbort()` static method.
+By default, an unexpected abort reason is warned to console. This behavior can be changed by assigning another
+unexpected failure handler with `Supply.onUnexpectedFailure()` static method.

--- a/src/abort/abort-supply-by.spec.ts
+++ b/src/abort/abort-supply-by.spec.ts
@@ -21,7 +21,7 @@ describe('abortSupplyBy', () => {
 
     const whenOff = jest.fn();
 
-    abortSupplyBy(signal, { off: whenOff });
+    abortSupplyBy(signal, whenOff);
 
     expect(whenOff).toHaveBeenCalledWith(expect.objectContaining({ error: reason }));
   });
@@ -30,7 +30,7 @@ describe('abortSupplyBy', () => {
 
     const whenOff = jest.fn();
 
-    abortSupplyBy(signal, { off: whenOff });
+    abortSupplyBy(signal, whenOff);
 
     expect(whenOff).toHaveBeenCalledWith(expect.objectContaining({ error: new SupplyAbortError() }));
   });

--- a/src/abort/abort-supply-by.spec.ts
+++ b/src/abort/abort-supply-by.spec.ts
@@ -23,7 +23,7 @@ describe('abortSupplyBy', () => {
 
     abortSupplyBy(signal, { off: whenOff });
 
-    expect(whenOff).toHaveBeenCalledWith(reason);
+    expect(whenOff).toHaveBeenCalledWith(expect.objectContaining({ error: reason }));
   });
   it('cuts off supply immediately by signal aborted without explicit reason', () => {
     abortCtl.abort();
@@ -32,7 +32,7 @@ describe('abortSupplyBy', () => {
 
     abortSupplyBy(signal, { off: whenOff });
 
-    expect(whenOff).toHaveBeenCalledWith(new SupplyAbortError());
+    expect(whenOff).toHaveBeenCalledWith(expect.objectContaining({ error: new SupplyAbortError() }));
   });
   it('cuts off supply when abort signal received', () => {
 
@@ -40,13 +40,13 @@ describe('abortSupplyBy', () => {
     const whenOff = jest.fn();
 
     supply.whenOff(whenOff);
-    expect(supply.isOff).toBe(false);
+    expect(supply.isOff).toBeUndefined();
 
     const reason = new Error('Aborted');
 
     abortCtl.abort(reason);
-    expect(supply.isOff).toBe(true);
-    expect(whenOff).toHaveBeenCalledWith(reason);
+    expect(supply.isOff).toMatchObject({ failed: true, error: reason });
+    expect(whenOff).toHaveBeenCalledWith(expect.objectContaining({ error: reason }));
   });
   it('cuts off supply when abort signal without explicit reason received', () => {
 
@@ -54,10 +54,10 @@ describe('abortSupplyBy', () => {
     const whenOff = jest.fn();
 
     supply.whenOff(whenOff);
-    expect(supply.isOff).toBe(false);
+    expect(supply.isOff).toBeUndefined();
 
     abortCtl.abort();
-    expect(supply.isOff).toBe(true);
-    expect(whenOff).toHaveBeenCalledWith(new SupplyAbortError());
+    expect(supply.isOff).toMatchObject({ failed: true, error: new SupplyAbortError() });
+    expect(whenOff).toHaveBeenCalledWith(expect.objectContaining({ error: new SupplyAbortError() }));
   });
 });

--- a/src/abort/abort-supply-by.ts
+++ b/src/abort/abort-supply-by.ts
@@ -1,3 +1,4 @@
+import { SupplyIsOff } from '../supply-is-off.js';
 import { SupplyReceiver } from '../supply-receiver.js';
 import { Supply, SupplyOut } from '../supply.js';
 import { SupplyAbortError } from './supply-abort.error.js';
@@ -19,12 +20,12 @@ export function abortSupplyBy(signal: AbortSignal, receiver?: SupplyReceiver): S
   const [supplyIn, supplyOut] = Supply.split(receiver);
 
   if (signal.aborted) {
-    supplyIn.off(SupplyAbortError.reasonOf(signal));
+    supplyIn.off(SupplyIsOff.becauseOf(SupplyAbortError.reasonOf(signal)));
   } else {
 
     const onAbort = (): void => {
       signal.removeEventListener('abort', onAbort);
-      supplyIn.off(SupplyAbortError.reasonOf(signal));
+      supplyIn.off(SupplyIsOff.becauseOf(SupplyAbortError.reasonOf(signal)));
     };
 
     signal.addEventListener('abort', onAbort);

--- a/src/abort/abort-supply-by.ts
+++ b/src/abort/abort-supply-by.ts
@@ -10,7 +10,7 @@ import { SupplyAbortError } from './supply-abort.error.js';
  *
  * @param signal - The signal that aborts the supply.
  * @param receiver - Optional supply receiver for contructed supplier. It can be useful to prevent the
- * {@link Supply.onUnexpectedAbort unexpected abort} in case the `signal` already aborted.
+ * {@link Supply.onUnexpectedFailure unexpected failure} in case the `signal` already aborted.
  *
  * @returns New supplier instance cut off once the `signal` aborted.
  */

--- a/src/abort/abort-supply-by.ts
+++ b/src/abort/abort-supply-by.ts
@@ -1,5 +1,5 @@
 import { SupplyIsOff } from '../supply-is-off.js';
-import { SupplyReceiver } from '../supply-receiver.js';
+import { SupplyReceiver, SupplyReceiverFn } from '../supply-receiver.js';
 import { Supply, SupplyOut } from '../supply.js';
 import { SupplyAbortError } from './supply-abort.error.js';
 
@@ -15,7 +15,7 @@ import { SupplyAbortError } from './supply-abort.error.js';
  *
  * @returns New supplier instance cut off once the `signal` aborted.
  */
-export function abortSupplyBy(signal: AbortSignal, receiver?: SupplyReceiver): SupplyOut {
+export function abortSupplyBy(signal: AbortSignal, receiver?: SupplyReceiver | SupplyReceiverFn): SupplyOut {
 
   const [supplyIn, supplyOut] = Supply.split(receiver);
 

--- a/src/abort/mod.ts
+++ b/src/abort/mod.ts
@@ -1,3 +1,2 @@
 export * from './abort-supply-by.js';
-export * from './supply-abort.error.js';
 export * from './supply-controller.js';

--- a/src/abort/supply-abort.error.ts
+++ b/src/abort/supply-abort.error.ts
@@ -16,7 +16,7 @@ export class SupplyAbortError extends Error {
       return;
     }
 
-    const { reason = new SupplyAbortError() } = signal;
+    const { reason = new SupplyAbortError } = signal;
 
     return reason;
   }

--- a/src/abort/supply-controller.spec.ts
+++ b/src/abort/supply-controller.spec.ts
@@ -5,22 +5,24 @@ import { SupplyController } from './supply-controller.js';
 
 describe('SupplyController', () => {
   it('cuts off the supply on abort', () => {
+
     const ctl = new SupplyController();
     const { supply } = ctl;
     const whenOff = jest.fn();
 
     supply.whenOff(whenOff);
 
-    expect(supply.isOff).toBe(false);
+    expect(supply.isOff).toBeUndefined();
 
     const reason = new Error('Aborted');
 
     ctl.abort(reason);
 
-    expect(supply.isOff).toBe(true);
-    expect(whenOff).toHaveBeenCalledWith(reason);
+    expect(supply.isOff?.error).toBe(reason);
+    expect(whenOff).toHaveBeenCalledWith(expect.objectContaining({ error: reason }));
   });
   it('aborts once supply cut off', () => {
+
     const whenOff = jest.fn();
     const supply = new Supply().whenOff(whenOff);
     const ctl = new SupplyController(supply);
@@ -33,9 +35,10 @@ describe('SupplyController', () => {
     ctl.supply.off(reason);
     expect(signal.aborted).toBe(true);
     expect(signal.reason).toBe(reason);
-    expect(whenOff).toHaveBeenCalledWith(reason);
+    expect(whenOff).toHaveBeenCalledWith(expect.objectContaining({ error: reason }));
   });
   it('aborts with `SupplyAbortError` once supply cut off without explicit reason', () => {
+
     const ctl = new SupplyController(new Supply().whenOff(() => void 0));
     const { signal } = ctl;
 

--- a/src/abort/supply-controller.spec.ts
+++ b/src/abort/supply-controller.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, jest } from '@jest/globals';
+import { SupplyIsOff } from '../supply-is-off.js';
 import { Supply } from '../supply.js';
-import { SupplyAbortError } from './supply-abort.error.js';
 import { SupplyController } from './supply-controller.js';
 
 describe('SupplyController', () => {
@@ -34,7 +34,7 @@ describe('SupplyController', () => {
 
     ctl.supply.off(reason);
     expect(signal.aborted).toBe(true);
-    expect(signal.reason).toBe(reason);
+    expect(signal.reason).toMatchObject({ failed: true, error: reason });
     expect(whenOff).toHaveBeenCalledWith(expect.objectContaining({ error: reason }));
   });
   it('aborts with `SupplyAbortError` once supply cut off without explicit reason', () => {
@@ -44,6 +44,7 @@ describe('SupplyController', () => {
 
     ctl.supply.off();
     expect(signal.aborted).toBe(true);
-    expect(signal.reason).toEqual(new SupplyAbortError());
+    expect(signal.reason).toBeInstanceOf(SupplyIsOff);
+    expect(signal.reason).toMatchObject({ failed: false });
   });
 });

--- a/src/abort/supply-controller.ts
+++ b/src/abort/supply-controller.ts
@@ -1,6 +1,5 @@
 import { Supply } from '../supply.js';
 import { abortSupplyBy } from './abort-supply-by.js';
-import { SupplyAbortError } from './supply-abort.error.js';
 
 /**
  * Supply controller is an `AbortController` that acts as a supplier and supply receiver.
@@ -20,7 +19,7 @@ export class SupplyController extends AbortController {
     super();
     this.#supply = abortSupplyBy(this.signal, supply)
         .derive(supply)
-        .whenOff(({ error = new SupplyAbortError }) => this.abort(error));
+        .whenOff(reason => this.abort(reason));
   }
 
   /**

--- a/src/abort/supply-controller.ts
+++ b/src/abort/supply-controller.ts
@@ -20,7 +20,7 @@ export class SupplyController extends AbortController {
     super();
     this.#supply = abortSupplyBy(this.signal, supply)
         .derive(supply)
-        .whenOff((reason = new SupplyAbortError) => this.abort(reason));
+        .whenOff(({ error = new SupplyAbortError }) => this.abort(error));
   }
 
   /**

--- a/src/always-supply.spec.ts
+++ b/src/always-supply.spec.ts
@@ -39,7 +39,10 @@ describe('alwaysSupply', () => {
   describe('alsoOff', () => {
     it('does nothing', () => {
 
-      const receiver = { off: jest.fn() };
+      const receiver = {
+        isOff: undefined,
+        off: jest.fn(),
+      };
       const supply = alwaysSupply();
 
       expect(supply.alsoOff(receiver)).toBe(alwaysSupply());

--- a/src/always-supply.spec.ts
+++ b/src/always-supply.spec.ts
@@ -5,12 +5,12 @@ import { Supply } from './supply.js';
 
 describe('alwaysSupply', () => {
   afterEach(() => {
-    Supply.onUnexpectedAbort();
+    Supply.onUnexpectedFailure();
   });
 
   describe('isOff', () => {
-    it('is always `false`', () => {
-      expect(alwaysSupply().isOff).toBe(false);
+    it('is always undefined', () => {
+      expect(alwaysSupply().isOff).toBeUndefined();
     });
   });
 
@@ -20,7 +20,7 @@ describe('alwaysSupply', () => {
       const supply = alwaysSupply();
 
       expect(supply.off()).toBe(alwaysSupply());
-      expect(supply.isOff).toBe(false);
+      expect(supply.isOff).toBeUndefined();
     });
   });
 
@@ -39,7 +39,7 @@ describe('alwaysSupply', () => {
   describe('alsoOff', () => {
     it('does nothing', () => {
 
-      const receiver = { isOff: false, off: jest.fn() };
+      const receiver = { off: jest.fn() };
       const supply = alwaysSupply();
 
       expect(supply.alsoOff(receiver)).toBe(alwaysSupply());
@@ -56,7 +56,7 @@ describe('alwaysSupply', () => {
       expect(supply.alsoOff(receiver)).toBe(alwaysSupply());
 
       supply.off();
-      expect(receiver.isOff).toBe(false);
+      expect(receiver.isOff).toBeUndefined();
       expect(whenOff).not.toHaveBeenCalled();
     });
   });
@@ -66,7 +66,7 @@ describe('alwaysSupply', () => {
 
       const onAbort = jest.fn();
 
-      Supply.onUnexpectedAbort(onAbort);
+      Supply.onUnexpectedFailure(onAbort);
 
       const supply = alwaysSupply();
       const otherSupply = new Supply();
@@ -74,8 +74,8 @@ describe('alwaysSupply', () => {
       expect(supply.needs(otherSupply)).toBe(alwaysSupply());
 
       otherSupply.off('reason');
-      expect(supply.isOff).toBe(false);
-      expect(onAbort).toHaveBeenCalledWith('reason');
+      expect(supply.isOff).toBeUndefined();
+      expect(onAbort).toHaveBeenCalledWith(expect.objectContaining({ error: 'reason' }));
       expect(onAbort).toHaveBeenCalledTimes(1);
     });
   });
@@ -91,14 +91,14 @@ describe('alwaysSupply', () => {
       expect(supply.as(otherSupply)).toBe(alwaysSupply());
 
       supply.off();
-      expect(otherSupply.isOff).toBe(false);
+      expect(otherSupply.isOff).toBeUndefined();
       expect(whenOff).not.toHaveBeenCalled();
     });
     it('never cuts off the always-supply', () => {
 
       const onAbort = jest.fn();
 
-      Supply.onUnexpectedAbort(onAbort);
+      Supply.onUnexpectedFailure(onAbort);
 
       const supply = alwaysSupply();
       const otherSupply = new Supply();
@@ -106,8 +106,8 @@ describe('alwaysSupply', () => {
       expect(supply.as(otherSupply)).toBe(alwaysSupply());
 
       otherSupply.off('reason');
-      expect(supply.isOff).toBe(false);
-      expect(onAbort).toHaveBeenCalledWith('reason');
+      expect(supply.isOff).toBeUndefined();
+      expect(onAbort).toHaveBeenCalledWith(expect.objectContaining({ error: 'reason' }));
       expect(onAbort).toHaveBeenCalledTimes(1);
     });
   });

--- a/src/always-supply.ts
+++ b/src/always-supply.ts
@@ -1,6 +1,5 @@
 import { Supplier } from './supplier.js';
-import { SupplyIsOff } from './supply-is-off.js';
-import { SupplyReceiver } from './supply-receiver.js';
+import { SupplyReceiver, SupplyReceiverFn } from './supply-receiver.js';
 import { Supply } from './supply.js';
 
 class AlwaysSupply extends Supply {
@@ -13,7 +12,7 @@ class AlwaysSupply extends Supply {
     return this;
   }
 
-  override whenOff(_callback: (this: void, reason: SupplyIsOff) => void): this {
+  override whenOff(_callback: SupplyReceiverFn): this {
     return this;
   }
 

--- a/src/always-supply.ts
+++ b/src/always-supply.ts
@@ -1,18 +1,19 @@
 import { Supplier } from './supplier.js';
+import { SupplyIsOff } from './supply-is-off.js';
 import { SupplyReceiver } from './supply-receiver.js';
 import { Supply } from './supply.js';
 
 class AlwaysSupply extends Supply {
 
-  override get isOff(): false {
-    return false;
+  override get isOff(): undefined {
+    return;
   }
 
   override off(_reason?: unknown): this {
     return this;
   }
 
-  override whenOff(_callback: (this: void, reason?: unknown) => void): this {
+  override whenOff(_callback: (this: void, reason: SupplyIsOff) => void): this {
     return this;
   }
 

--- a/src/impl/mod.ts
+++ b/src/impl/mod.ts
@@ -2,4 +2,4 @@ export * from './supply-state.js';
 export * from './supply-state.non-receiving.js';
 export * from './supply-state.off.js';
 export * from './supply-state.receiving.js';
-export * from './unexpected-abort.js';
+export * from './unexpected-failure.js';

--- a/src/impl/supply-state.non-receiving.ts
+++ b/src/impl/supply-state.non-receiving.ts
@@ -1,6 +1,7 @@
+import { SupplyIsOff } from '../supply-is-off.js';
 import { SupplyReceiver } from '../supply-receiver.js';
 import type { SupplyState } from './supply-state.js';
-import { Supply$off$unexpected, SupplyState$On } from './supply-state.on.js';
+import { SupplyState$On } from './supply-state.on.js';
 import { SupplyState$Receiving } from './supply-state.receiving.js';
 
 class SupplyState$NonReceiving$ extends SupplyState$On {
@@ -9,8 +10,8 @@ class SupplyState$NonReceiving$ extends SupplyState$On {
     update(new SupplyState$Receiving(receiver));
   }
 
-  protected override _off(reason: unknown): void {
-    Supply$off$unexpected(reason);
+  protected override _off(_reason: SupplyIsOff): false {
+    return false;
   }
 
 }

--- a/src/impl/supply-state.off.ts
+++ b/src/impl/supply-state.off.ts
@@ -1,13 +1,10 @@
+import { SupplyIsOff } from '../supply-is-off.js';
 import { SupplyReceiver } from '../supply-receiver.js';
 import type { SupplyState } from './supply-state.js';
 
-class SupplyState$Off implements SupplyState {
+export class SupplyState$Off implements SupplyState {
 
-  constructor(readonly whyOff: unknown) {
-  }
-
-  get isOff(): true {
-    return true;
+  constructor(readonly isOff: SupplyIsOff) {
   }
 
   off(_update: unknown, _reason?: unknown): void {
@@ -15,13 +12,7 @@ class SupplyState$Off implements SupplyState {
   }
 
   alsoOff(_update: unknown, receiver: SupplyReceiver): void {
-    receiver.off(this.whyOff);
+    receiver.off(this.isOff);
   }
 
-}
-
-const SupplyState$done = (/*#__PURE__*/ new SupplyState$Off(void 0));
-
-export function SupplyState$off(reason: unknown): SupplyState {
-  return reason === undefined ? SupplyState$done : new SupplyState$Off(reason);
 }

--- a/src/impl/supply-state.receiving.ts
+++ b/src/impl/supply-state.receiving.ts
@@ -1,3 +1,4 @@
+import { SupplyIsOff } from '../supply-is-off.js';
 import { SupplyReceiver } from '../supply-receiver.js';
 import { SupplyState } from './supply-state.js';
 import { SupplyState$On } from './supply-state.on.js';
@@ -30,12 +31,23 @@ export class SupplyState$Receiving extends SupplyState$On {
     }
   }
 
-  protected override _off(reason: unknown): void {
+  protected override _off(reason: SupplyIsOff): boolean {
+
+    let received = false;
+
     for (const receiver of this.#receivers) {
-      if (!receiver.isOff) {
+
+      const { isOff } = receiver;
+
+      if (!isOff) {
+        received = true;
         receiver.off(reason);
+      } else if (reason.sameTimeAs(isOff)) {
+        received = true;
       }
     }
+
+    return received;
   }
 
 }

--- a/src/impl/supply-state.ts
+++ b/src/impl/supply-state.ts
@@ -1,11 +1,11 @@
+import { SupplyIsOff } from '../supply-is-off.js';
 import { SupplyReceiver } from '../supply-receiver.js';
 
 export interface SupplyState {
 
-  readonly isOff: boolean;
-  readonly whyOff: unknown | undefined;
+  readonly isOff: SupplyIsOff | undefined;
 
-  off(update: (supply: SupplyState) => void, reason?: unknown): void;
+  off(update: (supply: SupplyState) => void, reason: SupplyIsOff): void;
 
   alsoOff(update: (supply: SupplyState) => void, receiver: SupplyReceiver): void;
 

--- a/src/impl/unexpected-abort.ts
+++ b/src/impl/unexpected-abort.ts
@@ -1,9 +1,0 @@
-export let Supply$unexpectedAbort: (reason: unknown) => void = Supply$unexpectedAbort$byDefault;
-
-export function Supply$unexpectedAbort$handle(handler = Supply$unexpectedAbort$byDefault): void {
-  Supply$unexpectedAbort = handler;
-}
-
-function Supply$unexpectedAbort$byDefault(reason: unknown): void {
-  console.error('Supply aborted unexpectedly.', reason);
-}

--- a/src/impl/unexpected-failure.ts
+++ b/src/impl/unexpected-failure.ts
@@ -1,0 +1,11 @@
+import { SupplyIsOff } from '../supply-is-off.js';
+
+export let Supply$unexpectedFailure: (reason: SupplyIsOff.Faultily) => void = Supply$unexpectedFailure$byDefault;
+
+export function Supply$unexpectedFailure$handle(handler = Supply$unexpectedFailure$byDefault): void {
+  Supply$unexpectedFailure = handler;
+}
+
+function Supply$unexpectedFailure$byDefault(reason: SupplyIsOff.Faultily): void {
+  console.error('Supply aborted unexpectedly.', reason.error);
+}

--- a/src/impl/unexpected-failure.ts
+++ b/src/impl/unexpected-failure.ts
@@ -7,5 +7,5 @@ export function Supply$unexpectedFailure$handle(handler = Supply$unexpectedFailu
 }
 
 function Supply$unexpectedFailure$byDefault(reason: SupplyIsOff.Faultily): void {
-  console.error('Supply aborted unexpectedly.', reason.error);
+  console.warn('Supply aborted unexpectedly.', reason.error);
 }

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -7,5 +7,6 @@ export * from './always-supply.js';
 export * from './never-supply.js';
 export * from './supplier.js';
 export * from './supply.js';
+export * from './supply-is-off.js';
 export * from './supply-receiver.js';
 export * from './timed-supply.js';

--- a/src/never-supply.spec.ts
+++ b/src/never-supply.spec.ts
@@ -1,13 +1,14 @@
 import { describe, expect, it, jest } from '@jest/globals';
 import { neverSupply } from './never-supply.js';
 import { Supplier } from './supplier.js';
+import { SupplyIsOff } from './supply-is-off.js';
 import { SupplyReceiver } from './supply-receiver.js';
 import { Supply } from './supply.js';
 
 describe('neverSupply', () => {
   describe('isOff', () => {
-    it('is always `true`', () => {
-      expect(neverSupply().isOff).toBe(true);
+    it('is always set', () => {
+      expect(neverSupply().isOff).toEqual(expect.objectContaining({ failed: false }));
     });
   });
 
@@ -31,16 +32,16 @@ describe('neverSupply', () => {
   describe('alsoOff', () => {
     it('informs the receiver immediately', () => {
 
-      const receiver = { isOff: false, off: jest.fn() };
+      const receiver = { isOff: undefined, off: jest.fn() };
       const supply = neverSupply();
 
       expect(supply.alsoOff(receiver)).toBe(neverSupply());
       supply.off('reason');
-      expect(receiver.off).toHaveBeenCalledWith();
+      expect(receiver.off).toHaveBeenCalledWith(expect.objectContaining({ failed: false }));
     });
     it('does not inform the unavailable receiver', () => {
 
-      const receiver = { isOff: true, off: jest.fn() };
+      const receiver = { isOff: new SupplyIsOff(), off: jest.fn() };
       const supply = neverSupply();
 
       expect(supply.alsoOff(receiver)).toBe(neverSupply());
@@ -57,14 +58,14 @@ describe('neverSupply', () => {
 
       supply.whenOff(whenOff);
       expect(neverSupply().as(supply)).toBe(neverSupply());
-      expect(supply.isOff).toBe(true);
-      expect(whenOff).toHaveBeenCalledWith(undefined);
+      expect(supply.isOff?.failed).toBe(false);
+      expect(whenOff).toHaveBeenCalledWith(expect.objectContaining({ failed: false }));
       expect(whenOff).toHaveBeenCalledTimes(1);
     });
     it('does not cut the unavailable receiver', () => {
 
       const receiver: Supplier & SupplyReceiver = {
-        isOff: true,
+        isOff: new SupplyIsOff(),
         off: jest.fn(),
         alsoOff: jest.fn(),
       };
@@ -83,7 +84,7 @@ describe('neverSupply', () => {
       const supply = new Supply();
 
       expect(neverSupply().needs(supply)).toBe(neverSupply());
-      expect(supply.isOff).toBe(false);
+      expect(supply.isOff).toBeUndefined();
     });
   });
 });

--- a/src/never-supply.ts
+++ b/src/never-supply.ts
@@ -1,11 +1,14 @@
 import { Supplier } from './supplier.js';
+import { SupplyIsOff } from './supply-is-off.js';
 import { SupplyReceiver } from './supply-receiver.js';
 import { Supply } from './supply.js';
 
+const neverSupply$isOff = /*#__PURE__*/ new SupplyIsOff();
+
 class NeverSupply extends Supply {
 
-  override get isOff(): true {
-    return true;
+  override get isOff(): SupplyIsOff {
+    return neverSupply$isOff;
   }
 
   override off(): this {
@@ -20,7 +23,7 @@ class NeverSupply extends Supply {
 
   override alsoOff(receiver: SupplyReceiver): this {
     if (!receiver.isOff) {
-      receiver.off();
+      receiver.off(this.isOff);
     }
 
     return this;

--- a/src/supply-is-off.spec.ts
+++ b/src/supply-is-off.spec.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from '@jest/globals';
+import { SupplyIsOff } from './supply-is-off.js';
+
+describe('SupplyIsOff', () => {
+  it('is successful by default', () => {
+
+    const isOff = new SupplyIsOff();
+
+    expect(isOff.failed).toBe(false);
+    expect(isOff.error).toBeUndefined();
+  });
+  it('is successful when error is not specified', () => {
+
+    const isOff = new SupplyIsOff({});
+
+    expect(isOff.failed).toBe(false);
+    expect(isOff.error).toBeUndefined();
+  });
+  it('ignores error if successful', () => {
+
+    const isOff = new SupplyIsOff({ failed: false, error: 'error' } as SupplyIsOff.AnyInit as SupplyIsOff.SuccessInit);
+
+    expect(isOff.failed).toBe(false);
+    expect(isOff.error).toBeUndefined();
+  });
+  it('is faulty if error specified', () => {
+
+    const isOff = new SupplyIsOff({ error: 'error' });
+
+    expect(isOff.failed).toBe(true);
+    expect(isOff.error).toBe('error');
+  });
+  it('is faulty if explicitly set and error omitted', () => {
+
+    const isOff = new SupplyIsOff({ failed: true, error: undefined });
+
+    expect(isOff.failed).toBe(true);
+    expect(isOff.error).toBeUndefined();
+  });
+
+  describe('derivation', () => {
+    it('derives faulty state and error', () => {
+
+      const base = new SupplyIsOff({ error: 'test error' });
+      const derived = new SupplyIsOff(base, {});
+
+      expect(derived.failed).toBe(true);
+      expect(derived.error).toBe('test error');
+    });
+    it('derives successful state', () => {
+
+      const base = new SupplyIsOff({});
+      const derived = new SupplyIsOff(base, {});
+
+      expect(derived.failed).toBe(false);
+      expect(derived.error).toBeUndefined();
+    });
+    it('overrides faulty state', () => {
+
+      const base = new SupplyIsOff({ error: 'test error' });
+      const derived = new SupplyIsOff(base, { failed: false });
+
+      expect(derived.failed).toBe(false);
+      expect(derived.error).toBeUndefined();
+    });
+    it('overrides successful state explicitly', () => {
+
+      const base = new SupplyIsOff({});
+      const derived = new SupplyIsOff(base, { failed: true });
+
+      expect(derived.failed).toBe(true);
+      expect(derived.error).toBeUndefined();
+    });
+    it('overrides failure error', () => {
+
+      const base = new SupplyIsOff({ error: 'test error' });
+      const derived = new SupplyIsOff(base, { error: 'other error' });
+
+      expect(derived.failed).toBe(true);
+      expect(derived.error).toBe('other error');
+    });
+    it('overrides successful state by error', () => {
+
+      const base = new SupplyIsOff({});
+      const derived = new SupplyIsOff(base, { error: 'test error' });
+
+      expect(derived.failed).toBe(true);
+      expect(derived.error).toBe('test error');
+    });
+  });
+
+  describe('sameTimeAs', () => {
+    it('returns `false` for independent indicators', () => {
+
+      const isOff1 = new SupplyIsOff();
+      const isOff2 = new SupplyIsOff();
+
+      expect(isOff1.sameTimeAs(isOff2)).toBe(false);
+      expect(isOff2.sameTimeAs(isOff1)).toBe(false);
+    });
+    it('returns `true` for the same indicator', () => {
+
+      const isOff = new SupplyIsOff();
+
+      expect(isOff.sameTimeAs(isOff)).toBe(true);
+    });
+    it('returns `true` for derived indicator', () => {
+
+      const isOff1 = new SupplyIsOff();
+      const isOff2 = new SupplyIsOff(isOff1, {});
+
+      expect(isOff1.sameTimeAs(isOff2)).toBe(true);
+      expect(isOff2.sameTimeAs(isOff1)).toBe(true);
+    });
+  });
+
+  describe('toString', () => {
+    it('indicates failure', () => {
+      expect(String(new SupplyIsOff({ error: 'test error' })))
+          .toMatch(/^SupplyIsOff\.Faultily#\d+\(error: test error\)$/);
+    });
+    it('indicates success', () => {
+      expect(String(new SupplyIsOff({})))
+          .toMatch(/^SupplyIsOff\.Successfully#\d+$/);
+    });
+  });
+});

--- a/src/supply-is-off.ts
+++ b/src/supply-is-off.ts
@@ -141,7 +141,7 @@ export namespace SupplyIsOff {
     /**
      * Whether supply failed.
      *
-     * Defaults to `true`.
+     * Defaults to `true` if {@link error} is also specified.
      */
     readonly failed?: boolean | undefined;
 
@@ -179,7 +179,7 @@ export namespace SupplyIsOff {
     /**
      * Always `false`, which means the supply succeed.
      */
-    readonly failed: false;
+    readonly failed?: false | undefined;
 
     /**
      * Always ignored.

--- a/src/supply-is-off.ts
+++ b/src/supply-is-off.ts
@@ -1,0 +1,213 @@
+let SupplyIsOff$rev = 0;
+
+/**
+ * An indicator of supply {@link Supply.isOff cut off}.
+ *
+ * Indicates why the supply has been cut off (i.e. due to failure or successful completion), and when this happened.
+ *
+ * It is used to wrap a reason why the supply has been cut off.
+ */
+export class SupplyIsOff {
+
+  /**
+   * Creates a supply cut off reason indicator caused by the given `reason`.
+   *
+   * - If the `reason` is an indicator already, just returns it.
+   * - Otherwise, if the `reason` is `undefined`, then creates new successful supply cut off indicator.
+   * - Otherwise, creates new failed supply cut off indicator, and uses the `reason` as supply failure {@link error}.
+   *
+   * @param reason - Supply cut off reason.
+   *
+   * @returns Supply cut off indicator cause by `reason`.
+   */
+  static becauseOf(reason?: unknown): SupplyIsOff {
+    return isSupplyIsOff(reason)
+        ? reason
+        : reason === undefined
+            ? new SupplyIsOff({ failed: false })
+            : new SupplyIsOff({ error: reason });
+  }
+
+  readonly #failed: boolean;
+  readonly #error: unknown | undefined;
+  readonly #whenOff: number;
+
+  /**
+   * Constructs an indicator.
+   *
+   * @param init - Initialization parameters. Successful supply completion indicator
+   */
+  constructor(init?: SupplyIsOff.Init);
+
+  /**
+   * Constructs an indicator derived from the `base` one.
+   *
+   * Constructed indicator will indicate cut off happened {@link sameTimeAs at the same time} as the `base` one.
+   *
+   * @param base - Base indicator to derive from.
+   * @param init - Initialization parameters overriding corresponding values from the `base` indicator.
+   */
+  constructor(base: SupplyIsOff, init: SupplyIsOff.AnyInit);
+
+  constructor(initOrBase: SupplyIsOff | SupplyIsOff.Init | undefined, optionalInit?: SupplyIsOff.AnyInit) {
+    if (!initOrBase) {
+      this.#failed = false;
+      this.#whenOff = ++SupplyIsOff$rev;
+    } else {
+
+      let base: SupplyIsOff | undefined;
+      let init: SupplyIsOff.AnyInit;
+
+      if (optionalInit) {
+        base = initOrBase as SupplyIsOff;
+        init = optionalInit;
+        this.#whenOff = base.#whenOff;
+      } else {
+        init = initOrBase as SupplyIsOff.Init;
+        this.#whenOff = ++SupplyIsOff$rev;
+      }
+
+      const { error = base?.error, failed = error !== undefined || base?.failed || false } = init;
+
+      this.#failed = failed;
+      this.#error = failed ? error : undefined;
+    }
+  }
+
+  /**
+   * Whether the supply has failed.
+   *
+   * When `true`, the {@link error} property contains a failure reason.
+   */
+  get failed(): boolean {
+    return this.#failed;
+  }
+
+  /**
+   * An error indicating supply failure reason.
+   *
+   * Contains value only when {@link failed} property is `true`. Contains `undefined` value otherwise.
+   */
+  get error(): unknown | undefined {
+    return this.#error;
+  }
+
+  /**
+   * A reference to itself.
+   *
+   * Use to detect a supply cut off indicator.
+   */
+  get isOff(): this {
+    return this;
+  }
+
+  /**
+   * Whether indicated cut off happened at the same time as `another` one.
+   *
+   * The supplies depending on the one cut off initially, considered cut off at the same time.
+   *
+   * @param another - Another cut off indicator.
+   */
+  sameTimeAs(another: SupplyIsOff): boolean {
+    return another.#whenOff === this.#whenOff;
+  }
+
+  toString(): string {
+    return this.failed
+        ? `SupplyIsOff.Faultily#${this.#whenOff}(error: ${this.error})`
+        : `SupplyIsOff.Successfully#${this.#whenOff}`;
+  }
+
+}
+
+function isSupplyIsOff(reason: unknown): reason is SupplyIsOff {
+  return typeof reason === 'object' && !!reason && (reason as Partial<SupplyIsOff>).isOff === reason;
+}
+
+export namespace SupplyIsOff {
+
+  /**
+   * Initialization parameters of supply cut off {@link SupplyIsOff indicator}.
+   *
+   * Provides either success of failure indication.
+   */
+  export type Init = FailureInit | SuccessInit;
+
+  /**
+   * Initialization parameters of arbitrary supply cut off {@link SupplyIsOff indicator}.
+   */
+  export interface AnyInit {
+
+    /**
+     * Whether supply failed.
+     *
+     * Defaults to `true`.
+     */
+    readonly failed?: boolean | undefined;
+
+    /**
+     * An error indicating supply failure reason.
+     *
+     * Ignored when {@link failed} flag set to `false`.
+     */
+    readonly error?: unknown | undefined;
+
+  }
+
+  /**
+   * Initialization parameters of failed supply cut off {@link SupplyIsOff indicator}.
+   */
+  export interface FailureInit extends AnyInit {
+
+    /**
+     * Either `true` or `undefined`, which means the supply failed.
+     */
+    readonly failed?: true | undefined;
+
+    /**
+     * An error indicating supply failure reason.
+     */
+    readonly error: unknown;
+
+  }
+
+  /**
+   * Initialization parameters of successful supply cut off {@link SupplyIsOff indicator}.
+   */
+  export interface SuccessInit extends AnyInit {
+
+    /**
+     * Always `false`, which means the supply succeed.
+     */
+    readonly failed: false;
+
+    /**
+     * Always ignored.
+     */
+    readonly error?: undefined;
+
+  }
+
+  /**
+   * An indicator of failed supply {@link Supply.isOff cut off}.
+   */
+  export interface Faultily extends SupplyIsOff {
+
+    get failed(): true;
+
+    get error(): unknown;
+
+  }
+
+  /**
+   * An indicator of successful supply {@link Supply.isOff cut off}.
+   */
+  export interface Successfully extends SupplyIsOff {
+
+    get failed(): false;
+
+    get error(): undefined;
+
+  }
+
+}

--- a/src/supply-is-off.ts
+++ b/src/supply-is-off.ts
@@ -4,8 +4,6 @@ let SupplyIsOff$rev = 0;
  * An indicator of supply {@link Supply.isOff cut off}.
  *
  * Indicates why the supply has been cut off (i.e. due to failure or successful completion), and when this happened.
- *
- * It is used to wrap a reason why the supply has been cut off.
  */
 export class SupplyIsOff {
 

--- a/src/supply-receiver.spec.ts
+++ b/src/supply-receiver.spec.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { Mock } from 'jest-mock';
+import { SupplyIsOff } from './supply-is-off.js';
+import { SupplyReceiver, SupplyReceiverFn } from './supply-receiver.js';
+import { Supply } from './supply.js';
+
+describe('SupplyReceiver', () => {
+  describe('for object', () => {
+    it('returns unconverted receiver', () => {
+
+      const receiver = {
+        isOff: undefined,
+        off: (_reason: SupplyIsOff) => void 0,
+      };
+
+      expect(SupplyReceiver(receiver)).toBe(receiver);
+    });
+  });
+
+  describe('for function', () => {
+
+    let supply: Supply;
+
+    beforeEach(() => {
+      supply = new Supply();
+    });
+
+    let whenOff: Mock<SupplyReceiverFn>;
+    let receiver: SupplyReceiver;
+
+    beforeEach(() => {
+      whenOff = jest.fn();
+      receiver = SupplyReceiver(whenOff);
+      supply.alsoOff(receiver);
+    });
+
+    it('calls receiver function on cut off', () => {
+      supply.off('reason');
+      expect(whenOff).toHaveBeenCalledWith(expect.objectContaining({ failed: true, error: 'reason' }));
+    });
+    it('makes receiver unavailable when cut off', () => {
+      supply.off('reason');
+
+      expect(receiver.isOff).toMatchObject({ failed: true, error: 'reason' });
+    });
+    it('calls receiver function at most once', () => {
+
+      const reason = new SupplyIsOff({ error: 'test' });
+
+      receiver.off(reason);
+      receiver.off(reason);
+
+      expect(whenOff).toHaveBeenCalledWith(reason);
+      expect(whenOff).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/supply-receiver.ts
+++ b/src/supply-receiver.ts
@@ -1,3 +1,5 @@
+import { SupplyIsOff } from './supply-is-off.js';
+
 /**
  * Supply receiver is informed when supply {@link Supply.off cut off}.
  *
@@ -11,17 +13,18 @@
  * Note that any {@link Supply} may act as a supply receiver.
  */
 export interface SupplyReceiver {
+
   /**
    * Indicates whether this receiver is unavailable.
    *
-   * It is expected that once this flag is set to `true`, it would never be reset.
+   * It is expected that once this indicator set , it would never be reset.
    *
-   * The supply would never call the {@link off} method of this receiver, once this flag is set.
+   * The supply would never call the {@link off} method of this receiver, once this indicator set.
    *
-   * The receiver with this flag set will be ignored by supplier when trying {@link Supplier.alsoOff register} it.
-   * Moreover, if this flag is set after the addition, the supplier may wish to remove it at any time.
+   * The receiver with this indicator set will be ignored by supplier when trying {@link Supplier.alsoOff register} it.
+   * Moreover, if this indicator set after the registration, the supplier may wish to remove it at any time.
    */
-  readonly isOff?: boolean | undefined;
+  readonly isOff?: SupplyIsOff | undefined;
 
   /**
    * Called by the source supply when the latter cut off.
@@ -32,8 +35,8 @@ export interface SupplyReceiver {
    * It is reasonable to set this property to no-op once the receiver becomes unavailable. This would release the
    * resources held by it, and help Garbage Collector to free them.
    *
-   * @param reason - An optional reason why the supply is cut off. By convenience, an absent reason means the supply is
-   * done successfully.
+   * @param reason - A reason indicating why the supply has been cut off, and when.
    */
-  off(reason?: unknown): void;
+  off(reason: SupplyIsOff): void;
+
 }

--- a/src/supply.spec.ts
+++ b/src/supply.spec.ts
@@ -466,6 +466,26 @@ describe('Supply', () => {
       expect(warnSpy).toHaveBeenCalledWith('Supply aborted unexpectedly.', 'reason');
       expect(warnSpy).toHaveBeenCalledTimes(1);
     });
+    it('does not report unexpected failure when supply depends on itself', () => {
+
+      const onFailure = jest.fn();
+
+      Supply.onUnexpectedFailure(onFailure);
+
+      const supply = new Supply();
+
+      supply.alsoOff({
+        get isOff() {
+          return supply.isOff;
+        },
+        off(reason) {
+          supply.off(reason);
+        },
+      });
+
+      supply.off('reason');
+      expect(onFailure).not.toHaveBeenCalled();
+    });
     it('replaces unexpected failure handler', () => {
 
       const onFailure = jest.fn();

--- a/src/supply.spec.ts
+++ b/src/supply.spec.ts
@@ -11,7 +11,7 @@ describe('Supply', () => {
 
   beforeEach(() => {
     whenOff = jest.fn();
-    supply = new Supply({ off: whenOff });
+    supply = new Supply(whenOff);
   });
   afterEach(() => {
     Supply.onUnexpectedFailure();
@@ -148,11 +148,14 @@ describe('Supply', () => {
 
   describe('alsoOff', () => {
     it('returns `this` instance', () => {
-      expect(supply.alsoOff({ off: () => {/* noop */} })).toBe(supply);
+      expect(supply.alsoOff(SupplyReceiver(() => void 0))).toBe(supply);
     });
     it('calls receiver', () => {
 
-      const receiver = { off: jest.fn() };
+      const receiver = {
+        isOff: undefined,
+        off: jest.fn(),
+      };
       const reason = 'reason';
 
       supply.alsoOff(receiver);
@@ -163,6 +166,7 @@ describe('Supply', () => {
     it('calls receiver without `isOff` implemented', () => {
 
       const receiver = {
+        isOff: undefined,
         off: jest.fn(),
       };
       const reason = 'reason';
@@ -175,7 +179,10 @@ describe('Supply', () => {
     it('calls the only receiver', () => {
       supply = new Supply();
 
-      const receiver = { off: jest.fn() };
+      const receiver = {
+        isOff: undefined,
+        off: jest.fn(),
+      };
       const reason = 'reason';
 
       supply.alsoOff(receiver);
@@ -198,6 +205,7 @@ describe('Supply', () => {
     it('does not call the receiver the became unavailable', () => {
 
       const receiver: TestSupplyReceiver = {
+        isOff: undefined,
         off: jest.fn(),
       };
 
@@ -211,6 +219,7 @@ describe('Supply', () => {
       supply = new Supply();
 
       const receiver: TestSupplyReceiver = {
+        isOff: undefined,
         off: jest.fn(),
       };
 
@@ -223,9 +232,11 @@ describe('Supply', () => {
     it('does not call preceding receiver that became unavailable', () => {
 
       const receiver1: TestSupplyReceiver = {
+        isOff: undefined,
         off: jest.fn(),
       };
       const receiver2: TestSupplyReceiver = {
+        isOff: undefined,
         off: jest.fn(),
       };
       const reason = 'reason';
@@ -242,9 +253,11 @@ describe('Supply', () => {
       supply = new Supply();
 
       const receiver1: TestSupplyReceiver = {
+        isOff: undefined,
         off: jest.fn(),
       };
       const receiver2: TestSupplyReceiver = {
+        isOff: undefined,
         off: jest.fn(),
       };
       const reason = 'reason';
@@ -261,12 +274,15 @@ describe('Supply', () => {
       supply = new Supply();
 
       const receiver1: TestSupplyReceiver = {
+        isOff: undefined,
         off: jest.fn(),
       };
       const receiver2: TestSupplyReceiver = {
+        isOff: undefined,
         off: jest.fn(),
       };
       const receiver3: TestSupplyReceiver = {
+        isOff: undefined,
         off: jest.fn(),
       };
       const reason = 'reason';
@@ -398,7 +414,7 @@ describe('Supply', () => {
     it('cuts off another supply when cutting this one off', () => {
 
       const whenDerivedOff = jest.fn();
-      const derivedSupply = new Supply({ off: whenDerivedOff });
+      const derivedSupply = new Supply(whenDerivedOff);
 
       expect(supply.derive(derivedSupply)).toBe(derivedSupply);
 
@@ -438,7 +454,7 @@ describe('Supply', () => {
     it('cuts off another supply when cutting this one off', () => {
 
       const whenAnotherOff = jest.fn();
-      const anotherSupply = new Supply({ off: whenAnotherOff });
+      const anotherSupply = new Supply(whenAnotherOff);
 
       expect(supply.as(anotherSupply)).toBe(supply);
 
@@ -513,6 +529,6 @@ describe('Supply', () => {
 });
 
 interface TestSupplyReceiver {
-  isOff?: SupplyReceiver['isOff'];
+  isOff: SupplyReceiver['isOff'];
   off: SupplyReceiver['off'];
 }

--- a/src/supply.spec.ts
+++ b/src/supply.spec.ts
@@ -451,20 +451,20 @@ describe('Supply', () => {
 
   describe('onUnexpectedFailure', () => {
 
-    let errorSpy: SpyInstance<(...args: unknown[]) => void>;
+    let warnSpy: SpyInstance<(...args: unknown[]) => void>;
 
     beforeEach(() => {
-      errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {/* noop */});
+      warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {/* noop */});
     });
     afterEach(() => {
-      errorSpy.mockRestore();
+      warnSpy.mockRestore();
     });
 
     it('logs failure reason by default', () => {
       new Supply().off('reason');
 
-      expect(errorSpy).toHaveBeenCalledWith('Supply aborted unexpectedly.', 'reason');
-      expect(errorSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy).toHaveBeenCalledWith('Supply aborted unexpectedly.', 'reason');
+      expect(warnSpy).toHaveBeenCalledTimes(1);
     });
     it('replaces unexpected failure handler', () => {
 
@@ -476,7 +476,7 @@ describe('Supply', () => {
 
       expect(onFailure).toHaveBeenCalledWith(expect.objectContaining({ error: 'reason' }));
       expect(onFailure).toHaveBeenCalledTimes(1);
-      expect(errorSpy).not.toHaveBeenCalled();
+      expect(warnSpy).not.toHaveBeenCalled();
     });
     it('reports failure reason only once', () => {
 

--- a/src/supply.ts
+++ b/src/supply.ts
@@ -273,7 +273,7 @@ export interface SupplyIn extends SupplyReceiver {
   /**
    * Indicates whether this supply is {@link off cut off} already.
    *
-   * Once set, nothing will be supplied anymore.
+   * `undefined` initially. Set once supply {@link off cut off}. Once set, nothing will be supplied anymore.
    */
   get isOff(): SupplyIsOff | undefined;
 
@@ -374,7 +374,7 @@ export interface SupplyOut extends Supplier {
   /**
    * Registers a supply receiver function that will be called as soon as this supply {@link Supply.off cut off}.
    *
-   * Calling this method is the same as calling `this.alsoOff(SupplyReceiver(callback))`
+   * Calling this method is the same as calling `this.alsoOff(SupplyReceiver(receiver))`
    *
    * @param receiver - Supply receiver function accepting cut off indicator as its only parameter.
    *
@@ -387,8 +387,7 @@ export interface SupplyOut extends Supplier {
    * immediately if supply is {@link Supply.isOff cut off} already.
    *
    * @returns A promise that will be successfully resolved once this supply completes {@link SupplyIsOff.Successfully
-   * successfully}, or rejected once this supply {@link SupplyIsOff.Faultily failed} with failure
-   * {@link SupplyIsOff.Faultily.error reason}.
+   * successfully}, or rejected with failure {@link SupplyIsOff.Faultily.error reason}.
    */
   whenDone(): Promise<void>;
 

--- a/src/supply.ts
+++ b/src/supply.ts
@@ -146,7 +146,7 @@ export class Supply extends SupplyOut implements SupplyIn {
    * {@link alsoOff supply receiver} registered and still {@link SupplyReceiver.isOff available} to handle it,
    * the given `handler` will be called with failure indicator as its only parameter.
    *
-   * By default, the unexpected failure {@link SupplyIsOff.Faultily.error reason} will be logged to console.
+   * By default, a warning with unexpected failure {@link SupplyIsOff.Faultily.error reason} will be issued to console.
    *
    * @param handler - A handler to call on unexpected failure, or `undefined` to reset to default one.
    */

--- a/src/timed-supply.spec.ts
+++ b/src/timed-supply.spec.ts
@@ -15,8 +15,7 @@ describe('timedSupply', () => {
 
     jest.advanceTimersByTime(10_000);
 
-    expect(supply.isOff).toBe(true);
-    expect(supply.whyOff).toEqual(new Error('Timed out after 10000 ms'));
+    expect(supply.isOff?.error).toEqual(new Error('Timed out after 10000 ms'));
   });
   it('cuts off the supply with custom reason after timeout', () => {
 
@@ -24,8 +23,7 @@ describe('timedSupply', () => {
 
     jest.advanceTimersByTime(10_000);
 
-    expect(supply.isOff).toBe(true);
-    expect(supply.whyOff).toBe('Test timeout: 10000');
+    expect(supply.isOff?.error).toBe('Test timeout: 10000');
   });
   it('can be cut off before the timeout', () => {
 
@@ -35,7 +33,6 @@ describe('timedSupply', () => {
     supply.off('test reason');
     jest.advanceTimersByTime(1000);
 
-    expect(supply.isOff).toBe(true);
-    expect(supply.whyOff).toBe('test reason');
+    expect(supply.isOff?.error).toBe('test reason');
   });
 });


### PR DESCRIPTION
- feat: represent supply cut off indication by `SupplyIsOff` instance
- chore: warn about unexpected failures
- test: add missing tests
- fix(abort): accept `SupplyIsOff` as an abort signal reason
- ferat: add `SupplyReceiverFn` function
- doc: document API changes related to `SupplyIsOff` indicator
