### PR TITLE
Rename `SupplyReceiver.off()` to `.cutOff()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,18 +60,26 @@ supply.off();
 A `Supply` is a class. Its constructor accepts optional callback instance. The latter will be called once the supply
 cut off.
 
+### `cutOff(reason: SuupplyIsOff)`
+
+[cut off]: #cutoffreason-suupplyisoff
+
+Cuts off the supply.
+
+When called for the first time, all registered supply receivers informed with the given `reason`, and [isOff]
+property value becomes equal to it. Calling this method for the second time has no effect.
+
+After this method call nothing would be supplied anymore.
+
 ### `off(reason?: unknown)`
 
-[off()]: #offreason-unknown
-[cut off]: #offreason-unknown
+Cuts off this supply with arbitrary reason.
 
-Calling this method cuts off the supply.
+Calling this method is the same as calling `this.cutOff(SupplyIsOff.becauseOf(reason))`.
 
-Accepts an optional reason. By convention `undefined` or absent reason means the supply is done successfully.
-Everything else means the supply is aborted abnormally because of that reason.
-
-When called, all registered cut off callbacks are called with the given reason and [isOff] property value becomes
-`true`.
+Accepts an optional reason why the supply is cut off. This reason converted to supply cut off {@link isOff indicator}.
+Everything else means the supply is aborted abnormally because of that reason. By convenience, `undefined` or missing
+`reason` means successful supply completion.
 
 ### `isOff`
 
@@ -155,7 +163,7 @@ Returns a supply instance that is already cut off without any particular reason.
 
 Builds an always-supply instance.
 
-The `off()` method of the returned supply does nothing.
+The `cutOff()` method of the returned supply does nothing.
 
 Returns a supply instance that can not be cut off.
 

--- a/src/always-supply.spec.ts
+++ b/src/always-supply.spec.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, jest } from '@jest/globals';
 import { alwaysSupply, isAlwaysSupply } from './always-supply.js';
 import { neverSupply } from './never-supply.js';
+import { SupplyIsOff } from './supply-is-off.js';
 import { Supply } from './supply.js';
 
 describe('alwaysSupply', () => {
@@ -11,6 +12,16 @@ describe('alwaysSupply', () => {
   describe('isOff', () => {
     it('is always undefined', () => {
       expect(alwaysSupply().isOff).toBeNull();
+    });
+  });
+
+  describe('cutOff', () => {
+    it('is no-op', () => {
+
+      const supply = alwaysSupply();
+
+      expect(supply.cutOff(new SupplyIsOff())).toBe(alwaysSupply());
+      expect(supply.isOff).toBeNull();
     });
   });
 
@@ -41,13 +52,13 @@ describe('alwaysSupply', () => {
 
       const receiver = {
         isOff: null,
-        off: jest.fn(),
+        cutOff: jest.fn(),
       };
       const supply = alwaysSupply();
 
       expect(supply.alsoOff(receiver)).toBe(alwaysSupply());
       supply.off('reason');
-      expect(receiver.off).not.toHaveBeenCalled();
+      expect(receiver.cutOff).not.toHaveBeenCalled();
     });
     it('never cuts dependent supply', () => {
 

--- a/src/always-supply.ts
+++ b/src/always-supply.ts
@@ -1,4 +1,5 @@
 import { Supplier } from './supplier.js';
+import { SupplyIsOff } from './supply-is-off.js';
 import { SupplyReceiver, SupplyReceiverFn } from './supply-receiver.js';
 import { Supply } from './supply.js';
 
@@ -8,15 +9,19 @@ class AlwaysSupply extends Supply {
     return null;
   }
 
+  override cutOff(_reason: SupplyIsOff): this {
+    return this;
+  }
+
   override off(_reason?: unknown): this {
     return this;
   }
 
-  override whenOff(_callback: SupplyReceiverFn): this {
+  override alsoOff(_receiver: SupplyReceiver): this {
     return this;
   }
 
-  override alsoOff(_receiver: SupplyReceiver): this {
+  override whenOff(_receiver: SupplyReceiverFn): this {
     return this;
   }
 

--- a/src/impl/fn-supply-receiver.ts
+++ b/src/impl/fn-supply-receiver.ts
@@ -1,0 +1,26 @@
+import { SupplyIsOff } from '../supply-is-off.js';
+import { SupplyReceiver, SupplyReceiverFn } from '../supply-receiver.js';
+
+export class FnSupplyReceiver implements SupplyReceiver {
+
+  #off: SupplyReceiverFn | null;
+  #isOff: SupplyIsOff | null = null;
+
+  constructor(off: SupplyReceiverFn) {
+    this.#off = off;
+  }
+
+  get isOff(): SupplyIsOff | null {
+    return this.#isOff;
+  }
+
+  cutOff(reason: SupplyIsOff): void {
+    this.#isOff = reason;
+
+    const off = this.#off;
+
+    this.#off = null;
+    off?.(reason);
+  }
+
+}

--- a/src/impl/mod.ts
+++ b/src/impl/mod.ts
@@ -1,3 +1,4 @@
+export * from './fn-supply-receiver.js';
 export * from './supply-state.js';
 export * from './supply-state.non-receiving.js';
 export * from './supply-state.off.js';

--- a/src/impl/supply-state.off.ts
+++ b/src/impl/supply-state.off.ts
@@ -12,7 +12,7 @@ export class SupplyState$Off implements SupplyState {
   }
 
   alsoOff(_update: unknown, receiver: SupplyReceiver): void {
-    receiver.off(this.isOff);
+    receiver.cutOff(this.isOff);
   }
 
 }

--- a/src/impl/supply-state.receiving.ts
+++ b/src/impl/supply-state.receiving.ts
@@ -41,7 +41,7 @@ export class SupplyState$Receiving extends SupplyState$On {
 
       if (!isOff) {
         received = true;
-        receiver.off(reason);
+        receiver.cutOff(reason);
       } else if (reason.sameTimeAs(isOff)) {
         received = true;
       }

--- a/src/never-supply.spec.ts
+++ b/src/never-supply.spec.ts
@@ -83,10 +83,10 @@ describe('neverSupply', () => {
       supply.whenOff(whenOff);
       expect(neverSupply().as(supply)).toBe(neverSupply());
       expect(supply.isOff?.failed).toBe(false);
-      expect(whenOff).toHaveBeenCalledWith(expect.objectContaining({ failed: false }));
+      expect(whenOff).toHaveBeenCalledWith(neverSupply().isOff);
       expect(whenOff).toHaveBeenCalledTimes(1);
     });
-    it('does not cut the unavailable receiver', () => {
+    it('does not cut unavailable receiver', () => {
 
       const receiver: Supplier & SupplyReceiver = {
         isOff: new SupplyIsOff(),

--- a/src/never-supply.ts
+++ b/src/never-supply.ts
@@ -1,6 +1,6 @@
 import { Supplier } from './supplier.js';
 import { SupplyIsOff } from './supply-is-off.js';
-import { SupplyReceiver } from './supply-receiver.js';
+import { SupplyReceiver, SupplyReceiverFn } from './supply-receiver.js';
 import { Supply } from './supply.js';
 
 const neverSupply$isOff = /*#__PURE__*/ new SupplyIsOff();
@@ -11,20 +11,24 @@ class NeverSupply extends Supply {
     return neverSupply$isOff;
   }
 
-  override off(): this {
+  override cutOff(_reason: SupplyIsOff): this {
     return this;
   }
 
-  override whenOff(callback: (reason?: any) => void): this {
-    callback();
-
+  override off(_reason?: unknown): this {
     return this;
   }
 
   override alsoOff(receiver: SupplyReceiver): this {
     if (!receiver.isOff) {
-      receiver.off(this.isOff);
+      receiver.cutOff(this.isOff);
     }
+
+    return this;
+  }
+
+  override whenOff(receiver: SupplyReceiverFn): this {
+    receiver(this.isOff);
 
     return this;
   }

--- a/src/supply-receiver.spec.ts
+++ b/src/supply-receiver.spec.ts
@@ -10,7 +10,7 @@ describe('SupplyReceiver', () => {
 
       const receiver = {
         isOff: null,
-        off: (_reason: SupplyIsOff) => void 0,
+        cutOff: (_reason: SupplyIsOff) => void 0,
       };
 
       expect(SupplyReceiver(receiver)).toBe(receiver);
@@ -47,8 +47,8 @@ describe('SupplyReceiver', () => {
 
       const reason = new SupplyIsOff({ error: 'test' });
 
-      receiver.off(reason);
-      receiver.off(reason);
+      receiver.cutOff(reason);
+      receiver.cutOff(reason);
 
       expect(whenOff).toHaveBeenCalledWith(reason);
       expect(whenOff).toHaveBeenCalledTimes(1);

--- a/src/supply-receiver.ts
+++ b/src/supply-receiver.ts
@@ -1,3 +1,4 @@
+import { FnSupplyReceiver } from './impl/mod.js';
 import { SupplyIsOff } from './supply-is-off.js';
 
 /**
@@ -19,7 +20,7 @@ export interface SupplyReceiver {
    *
    * It is expected that once this indicator set , it would never be reset.
    *
-   * The supply would never call the {@link off} method of this receiver, once this indicator set.
+   * The supply would never call the {@link cutOff} method of this receiver, once this indicator set.
    *
    * The receiver with this indicator set will be ignored by supplier when trying {@link Supplier.alsoOff register} it.
    * Moreover, if this indicator set after the registration, the supplier may wish to remove it at any time.
@@ -37,7 +38,7 @@ export interface SupplyReceiver {
    *
    * @param reason - A reason indicating why the supply has been cut off, and when.
    */
-  off(reason: SupplyIsOff): void;
+  cutOff(reason: SupplyIsOff): void;
 
 }
 
@@ -51,30 +52,6 @@ export interface SupplyReceiver {
  * @param reason - A reason indicating why the supply has been cut off, and when.
  */
 export type SupplyReceiverFn = (this: void, reason: SupplyIsOff) => void;
-
-class FnSupplyReceiver implements SupplyReceiver {
-
-  #off: SupplyReceiverFn | null;
-  #isOff: SupplyIsOff | null = null;
-
-  constructor(off: SupplyReceiverFn) {
-    this.#off = off;
-  }
-
-  get isOff(): SupplyIsOff | null {
-    return this.#isOff;
-  }
-
-  off(reason: SupplyIsOff): void {
-    this.#isOff = reason;
-
-    const off = this.#off;
-
-    this.#off = null;
-    off?.(reason);
-  }
-
-}
 
 /**
  * Converts a supply receiver function to supply receiver object.

--- a/src/supply.spec.ts
+++ b/src/supply.spec.ts
@@ -154,90 +154,90 @@ describe('Supply', () => {
 
       const receiver = {
         isOff: null,
-        off: jest.fn(),
+        cutOff: jest.fn(),
       };
       const reason = 'reason';
 
       supply.alsoOff(receiver);
       supply.off(reason);
 
-      expect(receiver.off).toHaveBeenCalledWith(expect.objectContaining({ error: reason }));
+      expect(receiver.cutOff).toHaveBeenCalledWith(expect.objectContaining({ error: reason }));
     });
     it('calls receiver without `isOff` implemented', () => {
 
       const receiver = {
         isOff: null,
-        off: jest.fn(),
+        cutOff: jest.fn(),
       };
       const reason = 'reason';
 
       supply.alsoOff(receiver);
       supply.off(reason);
 
-      expect(receiver.off).toHaveBeenCalledWith(expect.objectContaining({ error: reason }));
+      expect(receiver.cutOff).toHaveBeenCalledWith(expect.objectContaining({ error: reason }));
     });
     it('calls the only receiver', () => {
       supply = new Supply();
 
       const receiver = {
         isOff: null,
-        off: jest.fn(),
+        cutOff: jest.fn(),
       };
       const reason = 'reason';
 
       supply.alsoOff(receiver);
       supply.off(reason);
 
-      expect(receiver.off).toHaveBeenCalledWith(expect.objectContaining({ error: reason }));
+      expect(receiver.cutOff).toHaveBeenCalledWith(expect.objectContaining({ error: reason }));
     });
     it('does not call initially unavailable receiver', () => {
 
       const receiver = {
         isOff: new SupplyIsOff(),
-        off: jest.fn(),
+        cutOff: jest.fn(),
       };
 
       supply.alsoOff(receiver);
       supply.off();
 
-      expect(receiver.off).not.toHaveBeenCalled();
+      expect(receiver.cutOff).not.toHaveBeenCalled();
     });
     it('does not call the receiver the became unavailable', () => {
 
       const receiver: TestSupplyReceiver = {
         isOff: null,
-        off: jest.fn(),
+        cutOff: jest.fn(),
       };
 
       supply.alsoOff(receiver);
       receiver.isOff = new SupplyIsOff();
       supply.off();
 
-      expect(receiver.off).not.toHaveBeenCalled();
+      expect(receiver.cutOff).not.toHaveBeenCalled();
     });
     it('does not call the only receiver if it became unavailable', () => {
       supply = new Supply();
 
       const receiver: TestSupplyReceiver = {
         isOff: null,
-        off: jest.fn(),
+        cutOff: jest.fn(),
       };
 
       supply.alsoOff(receiver);
       receiver.isOff = new SupplyIsOff();
       supply.off();
 
-      expect(receiver.off).not.toHaveBeenCalled();
+      expect(receiver.cutOff).not.toHaveBeenCalled();
     });
     it('does not call preceding receiver that became unavailable', () => {
 
       const receiver1: TestSupplyReceiver = {
         isOff: null,
-        off: jest.fn(),
+        cutOff: jest.fn(),
       };
       const receiver2: TestSupplyReceiver = {
         isOff: null,
-        off: jest.fn(),
+        cutOff: jest.fn(),
       };
       const reason = 'reason';
 
@@ -246,19 +246,19 @@ describe('Supply', () => {
       receiver1.isOff = new SupplyIsOff();
       supply.off(reason);
 
-      expect(receiver1.off).not.toHaveBeenCalled();
-      expect(receiver2.off).toHaveBeenCalledWith(expect.objectContaining({ error: reason }));
+      expect(receiver1.cutOff).not.toHaveBeenCalled();
+      expect(receiver2.cutOff).toHaveBeenCalledWith(expect.objectContaining({ error: reason }));
     });
     it('does not call the only receiver that became unavailable before another one added', () => {
       supply = new Supply();
 
       const receiver1: TestSupplyReceiver = {
         isOff: null,
-        off: jest.fn(),
+        cutOff: jest.fn(),
       };
       const receiver2: TestSupplyReceiver = {
         isOff: null,
-        off: jest.fn(),
+        cutOff: jest.fn(),
       };
       const reason = 'reason';
 
@@ -267,23 +267,23 @@ describe('Supply', () => {
       supply.alsoOff(receiver2);
       supply.off(reason);
 
-      expect(receiver1.off).not.toHaveBeenCalled();
-      expect(receiver2.off).toHaveBeenCalledWith(expect.objectContaining({ error: reason }));
+      expect(receiver1.cutOff).not.toHaveBeenCalled();
+      expect(receiver2.cutOff).toHaveBeenCalledWith(expect.objectContaining({ error: reason }));
     });
     it('does not call all preceding receivers that became unavailable before another one added', () => {
       supply = new Supply();
 
       const receiver1: TestSupplyReceiver = {
         isOff: null,
-        off: jest.fn(),
+        cutOff: jest.fn(),
       };
       const receiver2: TestSupplyReceiver = {
         isOff: null,
-        off: jest.fn(),
+        cutOff: jest.fn(),
       };
       const receiver3: TestSupplyReceiver = {
         isOff: null,
-        off: jest.fn(),
+        cutOff: jest.fn(),
       };
       const reason = 'reason';
 
@@ -294,9 +294,9 @@ describe('Supply', () => {
       supply.alsoOff(receiver3);
       supply.off(reason);
 
-      expect(receiver1.off).not.toHaveBeenCalled();
-      expect(receiver2.off).not.toHaveBeenCalled();
-      expect(receiver3.off).toHaveBeenCalledWith(expect.objectContaining({ error: reason }));
+      expect(receiver1.cutOff).not.toHaveBeenCalled();
+      expect(receiver2.cutOff).not.toHaveBeenCalled();
+      expect(receiver3.cutOff).toHaveBeenCalledWith(expect.objectContaining({ error: reason }));
     });
   });
 
@@ -494,7 +494,7 @@ describe('Supply', () => {
         get isOff() {
           return supply.isOff;
         },
-        off(reason) {
+        cutOff(reason) {
           supply.off(reason);
         },
       });
@@ -530,5 +530,5 @@ describe('Supply', () => {
 
 interface TestSupplyReceiver {
   isOff: SupplyReceiver['isOff'];
-  off: SupplyReceiver['off'];
+  cutOff: SupplyReceiver['cutOff'];
 }


### PR DESCRIPTION
- feat: rename `SupplyReceiver.off()` to `SupplyReceiver.cutOff()`
- test: clarify `neverSupply()` tests
