### PR TITLE
Add support for supply results

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ property value becomes equal to it. Calling this method for the second time has 
 
 After this method call nothing would be supplied anymore.
 
+### `done(result)`
+
+Completes this supply with the given result.
+
+Calling this method is the same as calling `this.cutOff(new SupplyIsOff({ result }))`.
+
 ### `off(reason?: unknown)`
 
 Cuts off this supply with arbitrary reason.

--- a/src/impl/fn-supply-receiver.ts
+++ b/src/impl/fn-supply-receiver.ts
@@ -1,20 +1,20 @@
 import { SupplyIsOff } from '../supply-is-off.js';
 import { SupplyReceiver, SupplyReceiverFn } from '../supply-receiver.js';
 
-export class FnSupplyReceiver implements SupplyReceiver {
+export class FnSupplyReceiver<in out TResult> implements SupplyReceiver<TResult> {
 
-  #off: SupplyReceiverFn | null;
-  #isOff: SupplyIsOff | null = null;
+  #off: SupplyReceiverFn<TResult> | null;
+  #isOff: SupplyIsOff<TResult> | null = null;
 
-  constructor(off: SupplyReceiverFn) {
+  constructor(off: SupplyReceiverFn<TResult>) {
     this.#off = off;
   }
 
-  get isOff(): SupplyIsOff | null {
+  get isOff(): SupplyIsOff<TResult> | null {
     return this.#isOff;
   }
 
-  cutOff(reason: SupplyIsOff): void {
+  cutOff(reason: SupplyIsOff<TResult>): void {
     this.#isOff = reason;
 
     const off = this.#off;

--- a/src/impl/supply-state.non-receiving.ts
+++ b/src/impl/supply-state.non-receiving.ts
@@ -4,13 +4,13 @@ import type { SupplyState } from './supply-state.js';
 import { SupplyState$On } from './supply-state.on.js';
 import { SupplyState$Receiving } from './supply-state.receiving.js';
 
-class SupplyState$NonReceiving$ extends SupplyState$On {
+class SupplyState$NonReceiving$ extends SupplyState$On<never> {
 
-  override alsoOff(update: (state: SupplyState) => void, receiver: SupplyReceiver): void {
+  override alsoOff(update: (state: SupplyState<never>) => void, receiver: SupplyReceiver<never>): void {
     update(new SupplyState$Receiving(receiver));
   }
 
-  protected override _off(_reason: SupplyIsOff): false {
+  protected override _off(_reason: SupplyIsOff<never>): false {
     return false;
   }
 

--- a/src/impl/supply-state.off.ts
+++ b/src/impl/supply-state.off.ts
@@ -2,16 +2,16 @@ import { SupplyIsOff } from '../supply-is-off.js';
 import { SupplyReceiver } from '../supply-receiver.js';
 import type { SupplyState } from './supply-state.js';
 
-export class SupplyState$Off implements SupplyState {
+export class SupplyState$Off<out TResult> implements SupplyState<TResult> {
 
-  constructor(readonly isOff: SupplyIsOff) {
+  constructor(readonly isOff: SupplyIsOff<TResult>) {
   }
 
-  off(_update: unknown, _reason?: unknown): void {
+  off(_update: (supply: SupplyState<TResult>) => void, _reason?: SupplyIsOff<TResult>): void {
     // Already off.
   }
 
-  alsoOff(_update: unknown, receiver: SupplyReceiver): void {
+  alsoOff(_update: (supply: SupplyState<TResult>) => void, receiver: SupplyReceiver<TResult>): void {
     receiver.cutOff(this.isOff);
   }
 

--- a/src/impl/supply-state.on.ts
+++ b/src/impl/supply-state.on.ts
@@ -7,13 +7,13 @@ import { Supply$unexpectedFailure } from './unexpected-failure.js';
 let Supply$off: 0 | 1 = 0;
 let Supply$off$unexpected$reasons: Set<SupplyIsOff.Faultily> | undefined;
 
-export abstract class SupplyState$On implements SupplyState {
+export abstract class SupplyState$On<out TResult> implements SupplyState<TResult> {
 
   get isOff(): null {
     return null;
   }
 
-  off(update: (state: SupplyState) => void, reason: SupplyIsOff): void {
+  off(update: (state: SupplyState<TResult>) => void, reason: SupplyIsOff<TResult>): void {
     update(new SupplyState$Off(reason));
     if (Supply$off) {
       this.#off(reason);
@@ -28,11 +28,11 @@ export abstract class SupplyState$On implements SupplyState {
     }
   }
 
-  abstract alsoOff(update: (state: SupplyState) => void, receiver: SupplyReceiver): void;
+  abstract alsoOff(update: (state: SupplyState<TResult>) => void, receiver: SupplyReceiver<TResult>): void;
 
-  protected abstract _off(reason: SupplyIsOff): boolean;
+  protected abstract _off(reason: SupplyIsOff<TResult>): boolean;
 
-  #off(reason: SupplyIsOff): void {
+  #off(reason: SupplyIsOff<TResult>): void {
     if (!this._off(reason)) {
       Supply$off$unexpected(reason);
     }
@@ -40,7 +40,7 @@ export abstract class SupplyState$On implements SupplyState {
 
 }
 
-function Supply$off$unexpected(reason: SupplyIsOff): void {
+function Supply$off$unexpected(reason: SupplyIsOff<unknown>): void {
   if (reason.failed) {
     if (!Supply$off$unexpected$reasons) {
       Supply$off$unexpected$reasons = new Set();

--- a/src/impl/supply-state.receiving.ts
+++ b/src/impl/supply-state.receiving.ts
@@ -3,16 +3,16 @@ import { SupplyReceiver } from '../supply-receiver.js';
 import { SupplyState } from './supply-state.js';
 import { SupplyState$On } from './supply-state.on.js';
 
-export class SupplyState$Receiving extends SupplyState$On {
+export class SupplyState$Receiving<out TResult> extends SupplyState$On<TResult> {
 
-  readonly #receivers: SupplyReceiver[];
+  readonly #receivers: SupplyReceiver<TResult>[];
 
-  constructor(receiver: SupplyReceiver) {
+  constructor(receiver: SupplyReceiver<TResult>) {
     super();
     this.#receivers = [receiver];
   }
 
-  override alsoOff(_update: (state: SupplyState) => void, receiver: SupplyReceiver): void {
+  override alsoOff(_update: (state: SupplyState<TResult>) => void, receiver: SupplyReceiver<TResult>): void {
     this.#compact();
     this.#receivers.push(receiver);
   }
@@ -31,7 +31,7 @@ export class SupplyState$Receiving extends SupplyState$On {
     }
   }
 
-  protected override _off(reason: SupplyIsOff): boolean {
+  protected override _off(reason: SupplyIsOff<TResult>): boolean {
 
     let received = false;
 

--- a/src/impl/supply-state.ts
+++ b/src/impl/supply-state.ts
@@ -1,12 +1,12 @@
 import { SupplyIsOff } from '../supply-is-off.js';
 import { SupplyReceiver } from '../supply-receiver.js';
 
-export interface SupplyState {
+export interface SupplyState<out TResult> {
 
-  readonly isOff: SupplyIsOff | null;
+  readonly isOff: SupplyIsOff<TResult> | null;
 
-  off(update: (supply: SupplyState) => void, reason: SupplyIsOff): void;
+  off(update: (supply: SupplyState<TResult>) => void, reason: SupplyIsOff<TResult>): void;
 
-  alsoOff(update: (supply: SupplyState) => void, receiver: SupplyReceiver): void;
+  alsoOff(update: (supply: SupplyState<TResult>) => void, receiver: SupplyReceiver<TResult>): void;
 
 }

--- a/src/supplier.ts
+++ b/src/supplier.ts
@@ -4,8 +4,10 @@ import { SupplyReceiver } from './supply-receiver.js';
  * Supplier informs the receivers when supply is cut off.
  *
  * Note that any {@link Supply} may act as a supplier.
+ *
+ * @typeParam TResult - Supply result type.
  */
-export interface Supplier {
+export interface Supplier<in TResult = void> {
 
   /**
    * Registers a receiver of the supply.
@@ -17,6 +19,6 @@ export interface Supplier {
    *
    * @param receiver - Supply receiver to register.
    */
-  alsoOff(receiver: SupplyReceiver): void;
+  alsoOff(receiver: SupplyReceiver<TResult>): void;
 
 }

--- a/src/supply-is-off.spec.ts
+++ b/src/supply-is-off.spec.ts
@@ -20,10 +20,36 @@ describe('SupplyIsOff', () => {
   });
   it('ignores error if successful', () => {
 
-    const isOff = new SupplyIsOff({ failed: false, error: 'error' } as SupplyIsOff.AnyInit as SupplyIsOff.SuccessInit);
+    const isOff = new SupplyIsOff({
+      failed: false,
+      error: 'error',
+    } as SupplyIsOff.AnyInit as SupplyIsOff.SuccessInit);
 
     expect(isOff.failed).toBe(false);
     expect(isOff.error).toBeUndefined();
+    expect(isOff.result).toBeUndefined();
+  });
+  it('ignores result if faulty', () => {
+
+    const isOff = new SupplyIsOff({
+      failed: true,
+      result: 1,
+    } as SupplyIsOff.AnyInit<number> as SupplyIsOff.FailureInit);
+
+    expect(isOff.failed).toBe(true);
+    expect(isOff.error).toBeUndefined();
+    expect(isOff.result).toBeUndefined();
+  });
+  it('ignores result if error present', () => {
+
+    const isOff = new SupplyIsOff({
+      error: 'error',
+      result: 1,
+    } as SupplyIsOff.AnyInit<number> as SupplyIsOff.FailureInit);
+
+    expect(isOff.failed).toBe(true);
+    expect(isOff.error).toBe('error');
+    expect(isOff.result).toBeUndefined();
   });
   it('is faulty if error specified', () => {
 

--- a/src/supply-is-off.spec.ts
+++ b/src/supply-is-off.spec.ts
@@ -8,6 +8,7 @@ describe('SupplyIsOff', () => {
 
     expect(isOff.failed).toBe(false);
     expect(isOff.error).toBeUndefined();
+    expect(isOff.result).toBeUndefined();
   });
   it('is successful when error is not specified', () => {
 
@@ -15,6 +16,7 @@ describe('SupplyIsOff', () => {
 
     expect(isOff.failed).toBe(false);
     expect(isOff.error).toBeUndefined();
+    expect(isOff.result).toBeUndefined();
   });
   it('ignores error if successful', () => {
 
@@ -29,6 +31,7 @@ describe('SupplyIsOff', () => {
 
     expect(isOff.failed).toBe(true);
     expect(isOff.error).toBe('error');
+    expect(isOff.result).toBeUndefined();
   });
   it('is faulty if explicitly set and error omitted', () => {
 
@@ -36,6 +39,7 @@ describe('SupplyIsOff', () => {
 
     expect(isOff.failed).toBe(true);
     expect(isOff.error).toBeUndefined();
+    expect(isOff.result).toBeUndefined();
   });
 
   describe('derivation', () => {
@@ -46,6 +50,7 @@ describe('SupplyIsOff', () => {
 
       expect(derived.failed).toBe(true);
       expect(derived.error).toBe('test error');
+      expect(derived.result).toBeUndefined();
     });
     it('derives successful state', () => {
 
@@ -54,6 +59,16 @@ describe('SupplyIsOff', () => {
 
       expect(derived.failed).toBe(false);
       expect(derived.error).toBeUndefined();
+      expect(derived.result).toBeUndefined();
+    });
+    it('derives result', () => {
+
+      const base = new SupplyIsOff({ result: 1 });
+      const derived = new SupplyIsOff(base, {});
+
+      expect(derived.failed).toBe(false);
+      expect(derived.error).toBeUndefined();
+      expect(derived.result).toBe(1);
     });
     it('overrides faulty state', () => {
 
@@ -62,6 +77,7 @@ describe('SupplyIsOff', () => {
 
       expect(derived.failed).toBe(false);
       expect(derived.error).toBeUndefined();
+      expect(derived.result).toBeUndefined();
     });
     it('overrides successful state explicitly', () => {
 
@@ -70,6 +86,24 @@ describe('SupplyIsOff', () => {
 
       expect(derived.failed).toBe(true);
       expect(derived.error).toBeUndefined();
+      expect(derived.result).toBeUndefined();
+    });
+    it('overrides result', () => {
+
+      const base = new SupplyIsOff<number>({ result: 1 });
+      const derived = new SupplyIsOff(base, { result: 13 });
+
+      expect(derived.failed).toBe(false);
+      expect(derived.error).toBeUndefined();
+      expect(derived.result).toBe(13);
+    });
+    it('overrides faulty state by result', () => {
+      const base = new SupplyIsOff<number>({ error: 'test error' });
+      const derived = new SupplyIsOff(base, { result: 13 });
+
+      expect(derived.failed).toBe(false);
+      expect(derived.error).toBeUndefined();
+      expect(derived.result).toBe(13);
     });
     it('overrides failure error', () => {
 

--- a/src/supply-is-off.ts
+++ b/src/supply-is-off.ts
@@ -5,7 +5,7 @@ let SupplyIsOff$rev = 0;
  *
  * Indicates why the supply has been cut off (i.e. due to failure or successful completion), and when this happened.
  */
-export class SupplyIsOff {
+export class SupplyIsOff<out TResult = void> {
 
   /**
    * Creates a supply cut off reason indicator caused by the given `reason`.
@@ -22,12 +22,13 @@ export class SupplyIsOff {
     return isSupplyIsOff(reason)
         ? reason
         : reason === undefined
-            ? new SupplyIsOff({ failed: false })
+            ? new SupplyIsOff()
             : new SupplyIsOff({ error: reason });
   }
 
   readonly #failed: boolean;
   readonly #error: unknown | undefined;
+  readonly #result: TResult | undefined;
   readonly #whenOff: number;
 
   /**
@@ -35,7 +36,10 @@ export class SupplyIsOff {
    *
    * @param init - Initialization parameters. Successful supply completion indicator
    */
-  constructor(init?: SupplyIsOff.Init);
+  constructor(...init: undefined extends TResult
+      ? [init?: SupplyIsOff.Init<TResult>]
+      : [init: SupplyIsOff.Init<TResult>]
+  );
 
   /**
    * Constructs an indicator derived from the `base` one.
@@ -45,30 +49,50 @@ export class SupplyIsOff {
    * @param base - Base indicator to derive from.
    * @param init - Initialization parameters overriding corresponding values from the `base` indicator.
    */
-  constructor(base: SupplyIsOff, init: SupplyIsOff.AnyInit);
+  constructor(base: SupplyIsOff<TResult>, init: SupplyIsOff.AnyInit<TResult>);
 
-  constructor(initOrBase: SupplyIsOff | SupplyIsOff.Init | undefined, optionalInit?: SupplyIsOff.AnyInit) {
+  constructor(
+      initOrBase?: SupplyIsOff<TResult> | SupplyIsOff.Init<TResult>,
+      optionalInit?: SupplyIsOff.AnyInit<TResult>,
+  ) {
     if (!initOrBase) {
       this.#failed = false;
       this.#whenOff = ++SupplyIsOff$rev;
     } else {
 
-      let base: SupplyIsOff | undefined;
-      let init: SupplyIsOff.AnyInit;
+      let base: SupplyIsOff<TResult> | undefined;
+      let init: SupplyIsOff.AnyInit<TResult>;
 
       if (optionalInit) {
-        base = initOrBase as SupplyIsOff;
+        base = initOrBase as SupplyIsOff<TResult>;
         init = optionalInit;
         this.#whenOff = base.#whenOff;
       } else {
-        init = initOrBase as SupplyIsOff.Init;
+        init = initOrBase as SupplyIsOff.Init<TResult>;
         this.#whenOff = ++SupplyIsOff$rev;
       }
 
-      const { error = base?.error, failed = error !== undefined || base?.failed || false } = init;
+      const {
+        error,
+        result,
+        failed = error !== undefined
+            ? true
+            : result !== undefined
+                ? false
+                : (base?.failed || false),
+        } = init;
 
       this.#failed = failed;
-      this.#error = failed ? error : undefined;
+      this.#error = failed
+          ? error !== undefined
+              ? error
+              : base?.error
+          : undefined;
+      this.#result = failed
+          ? undefined
+          : result !== undefined
+              ? result
+              : base?.result;
     }
   }
 
@@ -84,10 +108,19 @@ export class SupplyIsOff {
   /**
    * An error indicating supply failure reason.
    *
-   * Contains value only when {@link failed} property is `true`. Contains `undefined` value otherwise.
+   * Contains value only when {@link failed} flag is `true`. Contains `undefined` value otherwise.
    */
   get error(): unknown | undefined {
     return this.#error;
+  }
+
+  /**
+   * A result of successfully completed supply.
+   *
+   * Contains value only when {@link failed} flag is `false`. Contains `undefined` otherwise.
+   */
+  get result(): TResult | undefined {
+    return this.#result;
   }
 
   /**
@@ -129,12 +162,14 @@ export namespace SupplyIsOff {
    *
    * Provides either success of failure indication.
    */
-  export type Init = FailureInit | SuccessInit;
+  export type Init<TResult = void> = undefined extends TResult
+      ? FailureInit | SuccessInit | ResultInit<TResult>
+      : FailureInit | ResultInit<TResult>;
 
   /**
    * Initialization parameters of arbitrary supply cut off {@link SupplyIsOff indicator}.
    */
-  export interface AnyInit {
+  export interface AnyInit<out TResult = void> {
 
     /**
      * Whether supply failed.
@@ -149,6 +184,13 @@ export namespace SupplyIsOff {
      * Ignored when {@link failed} flag set to `false`.
      */
     readonly error?: unknown | undefined;
+
+    /**
+     * A result of successfully completed supply.
+     *
+     * Ignored when {@link failed} flag set to `false`, or {@link error} is present.
+     */
+    readonly result?: TResult | undefined;
 
   }
 
@@ -167,6 +209,11 @@ export namespace SupplyIsOff {
      */
     readonly error: unknown;
 
+    /**
+     * Always ignored.
+     */
+    readonly result?: undefined;
+
   }
 
   /**
@@ -184,6 +231,33 @@ export namespace SupplyIsOff {
      */
     readonly error?: undefined;
 
+    /**
+     *  A result of successfully completed supply.
+     */
+    readonly result?: undefined;
+
+  }
+
+  /**
+   * Initialization parameters of successful supply cut off {@link SupplyIsOff indicator}.
+   */
+  export interface ResultInit<out TResult = void> extends AnyInit<TResult> {
+
+    /**
+     * Always `false`, which means the supply succeed.
+     */
+    readonly failed?: false | undefined;
+
+    /**
+     * Always ignored.
+     */
+    readonly error?: undefined;
+
+    /**
+     *  A result of successfully completed supply.
+     */
+    readonly result: TResult;
+
   }
 
   /**
@@ -200,7 +274,7 @@ export namespace SupplyIsOff {
   /**
    * An indicator of successful supply {@link Supply.isOff cut off}.
    */
-  export interface Successfully extends SupplyIsOff {
+  export interface Successfully<out TResult = void> extends SupplyIsOff<TResult> {
 
     get failed(): false;
 

--- a/src/supply-is-off.ts
+++ b/src/supply-is-off.ts
@@ -20,10 +20,8 @@ export class SupplyIsOff<out TResult = void> {
    *
    * @returns Supply cut off indicator cause by `reason`.
    */
-  static becauseOf<TResult>(
-      ...[reason]: undefined extends TResult
-          ? [reason?: unknown]
-          : [reason: unknown]
+  static becauseOf<TReason, TResult = void>(
+      ...[reason]: SupplyIsOff.ReasonArgs<TResult, TReason>
   ): SupplyIsOff<TResult> {
     return isSupplyIsOff<TResult>(reason)
         ? reason
@@ -300,5 +298,15 @@ export namespace SupplyIsOff {
     get result(): TResult;
 
   }
+
+  export type Reason<TResult, TReason> = TReason extends SupplyIsOff<TResult>
+      ? TReason
+      : TReason extends SupplyIsOff<unknown>
+          ? never
+          : TReason;
+
+  export type ReasonArgs<TResult, TReason> = undefined extends TResult
+      ? [reason?: Reason<TResult, TReason>]
+      : [reason: Reason<TResult, TReason>];
 
 }

--- a/src/supply-is-off.ts
+++ b/src/supply-is-off.ts
@@ -4,6 +4,8 @@ let SupplyIsOff$rev = 0;
  * An indicator of supply {@link Supply.isOff cut off}.
  *
  * Indicates why the supply has been cut off (i.e. due to failure or successful completion), and when this happened.
+ *
+ * @typeParam TResult - Supply result type.
  */
 export class SupplyIsOff<out TResult = void> {
 
@@ -18,11 +20,15 @@ export class SupplyIsOff<out TResult = void> {
    *
    * @returns Supply cut off indicator cause by `reason`.
    */
-  static becauseOf(reason?: unknown): SupplyIsOff {
-    return isSupplyIsOff(reason)
+  static becauseOf<TResult>(
+      ...[reason]: undefined extends TResult
+          ? [reason?: unknown]
+          : [reason: unknown]
+  ): SupplyIsOff<TResult> {
+    return isSupplyIsOff<TResult>(reason)
         ? reason
         : reason === undefined
-            ? new SupplyIsOff()
+            ? new SupplyIsOff(undefined!)
             : new SupplyIsOff({ error: reason });
   }
 
@@ -36,9 +42,10 @@ export class SupplyIsOff<out TResult = void> {
    *
    * @param init - Initialization parameters. Successful supply completion indicator
    */
-  constructor(...init: undefined extends TResult
-      ? [init?: SupplyIsOff.Init<TResult>]
-      : [init: SupplyIsOff.Init<TResult>]
+  constructor(
+      ...init: undefined extends TResult
+          ? [init?: SupplyIsOff.Init<TResult>]
+          : [init: SupplyIsOff.Init<TResult>]
   );
 
   /**
@@ -139,7 +146,7 @@ export class SupplyIsOff<out TResult = void> {
    *
    * @param another - Another cut off indicator.
    */
-  sameTimeAs(another: SupplyIsOff): boolean {
+  sameTimeAs(another: SupplyIsOff<unknown>): boolean {
     return another.#whenOff === this.#whenOff;
   }
 
@@ -151,7 +158,7 @@ export class SupplyIsOff<out TResult = void> {
 
 }
 
-function isSupplyIsOff(reason: unknown): reason is SupplyIsOff {
+function isSupplyIsOff<TResult>(reason: unknown): reason is SupplyIsOff<TResult> {
   return typeof reason === 'object' && !!reason && (reason as Partial<SupplyIsOff>).isOff === reason;
 }
 
@@ -161,6 +168,8 @@ export namespace SupplyIsOff {
    * Initialization parameters of supply cut off {@link SupplyIsOff indicator}.
    *
    * Provides either success of failure indication.
+   *
+   * @typeParam TResult - Supply result type.
    */
   export type Init<TResult = void> = undefined extends TResult
       ? FailureInit | SuccessInit | ResultInit<TResult>
@@ -168,6 +177,8 @@ export namespace SupplyIsOff {
 
   /**
    * Initialization parameters of arbitrary supply cut off {@link SupplyIsOff indicator}.
+   *
+   * @typeParam TResult - Supply result type.
    */
   export interface AnyInit<out TResult = void> {
 
@@ -240,6 +251,8 @@ export namespace SupplyIsOff {
 
   /**
    * Initialization parameters of successful supply cut off {@link SupplyIsOff indicator}.
+   *
+   * @typeParam TResult - Supply result type.
    */
   export interface ResultInit<out TResult = void> extends AnyInit<TResult> {
 
@@ -269,16 +282,22 @@ export namespace SupplyIsOff {
 
     get error(): unknown;
 
+    get result(): undefined;
+
   }
 
   /**
    * An indicator of successful supply {@link Supply.isOff cut off}.
+   *
+   * @typeParam TResult - Supply result type.
    */
   export interface Successfully<out TResult = void> extends SupplyIsOff<TResult> {
 
     get failed(): false;
 
     get error(): undefined;
+
+    get result(): TResult;
 
   }
 

--- a/src/supply-receiver.ts
+++ b/src/supply-receiver.ts
@@ -12,8 +12,10 @@ import { SupplyIsOff } from './supply-is-off.js';
  * unavailable}, so that the supplier would be able to remove it occasionally.
  *
  * Note that any {@link Supply} may act as a supply receiver.
+ *
+ * @typeParam TResult - Supply result type.
  */
-export interface SupplyReceiver {
+export interface SupplyReceiver<out TResult = void> {
 
   /**
    * Indicates whether this receiver is unavailable.
@@ -25,7 +27,7 @@ export interface SupplyReceiver {
    * The receiver with this indicator set will be ignored by supplier when trying {@link Supplier.alsoOff register} it.
    * Moreover, if this indicator set after the registration, the supplier may wish to remove it at any time.
    */
-  readonly isOff: SupplyIsOff | null;
+  readonly isOff: SupplyIsOff<TResult> | null;
 
   /**
    * Called by the source supply when the latter cut off.
@@ -38,7 +40,7 @@ export interface SupplyReceiver {
    *
    * @param reason - A reason indicating why the supply has been cut off, and when.
    */
-  cutOff(reason: SupplyIsOff): void;
+  cutOff(reason: SupplyIsOff<TResult>): void;
 
 }
 
@@ -49,19 +51,23 @@ export interface SupplyReceiver {
  *
  * Can be converted to {@link SupplyReceiver}.
  *
+ * @typeParam TResult - Supply result type.
  * @param reason - A reason indicating why the supply has been cut off, and when.
  */
-export type SupplyReceiverFn = (this: void, reason: SupplyIsOff) => void;
+export type SupplyReceiverFn<in TResult = void> = (this: void, reason: SupplyIsOff<TResult>) => void;
 
 /**
  * Converts a supply receiver function to supply receiver object.
  *
  * When called for `receiver` object, just returns it.
  *
+ * @typeParam TResult - Supply result type.
  * @param receiver - Either receiver function to convert, or receiver object.
  *
  * @returns Supply receiver object that calls the given function when supply cut off at most once.
  */
-export function SupplyReceiver(receiver: SupplyReceiver | SupplyReceiverFn): SupplyReceiver {
+export function SupplyReceiver<TResult = void>(
+    receiver: SupplyReceiver<TResult> | SupplyReceiverFn<TResult>,
+): SupplyReceiver<TResult> {
   return typeof receiver === 'function' ? new FnSupplyReceiver(receiver) : receiver;
 }

--- a/src/supply.ts
+++ b/src/supply.ts
@@ -47,12 +47,8 @@ class SupplyIn$<in out TResult> implements SupplyIn<TResult> {
     return this.cutOff(new SupplyIsOff({ result }));
   }
 
-  off(
-      ...[reason]: undefined extends TResult
-          ? [reason?: unknown]
-          : [reason: unknown]
-  ): this {
-    return this.cutOff(SupplyIsOff.becauseOf(reason));
+  off<TReason>(...reason: SupplyIsOff.ReasonArgs<TResult, TReason>): this {
+    return this.cutOff(SupplyIsOff.becauseOf(...reason));
   }
 
   needs(supplier: Supplier<TResult>): this {
@@ -226,12 +222,8 @@ export class Supply<in out TResult = void> extends SupplyOut<TResult> implements
     return this;
   }
 
-  off(
-      ...[reason]: undefined extends TResult
-          ? [reason?: unknown]
-          : [reason: unknown]
-  ): this {
-    this.#in.off(reason);
+  off<TReason>(...reason: SupplyIsOff.ReasonArgs<TResult, TReason>): this {
+    this.#in.off(...reason);
 
     return this;
   }
@@ -356,17 +348,14 @@ export interface SupplyIn<in out TResult = void> extends SupplyReceiver<TResult>
    *
    * Calling this method is the same as calling `this.cutOff(SupplyIsOff.becauseOf(reason))`.
    *
+   * @typeParam - Type of cut off reason.
    * @param reason - An optional reason why the supply is cut off. This reason {@link SupplyIsOff.becauseOf converted}
    * to supply cut off {@link isOff indicator}. By convenience, `undefined` or missing `reason` means successful supply
    * completion.
    *
    * @returns `this` instance.
    */
-  off(
-      ...reason: undefined extends TResult
-          ? [reason?: unknown]
-          : [reason: unknown]
-  ): this;
+  off<TReason>(...reason: SupplyIsOff.ReasonArgs<TResult, TReason>): this;
 
   /**
    * Makes this supply depend on another supplier.

--- a/src/timed-supply.spec.ts
+++ b/src/timed-supply.spec.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { SupplyIsOff } from './supply-is-off.js';
+import { Supply } from './supply.js';
 import { timedSupply } from './timed-supply.js';
 
 describe('timedSupply', () => {
@@ -14,6 +15,15 @@ describe('timedSupply', () => {
 
     const supply = timedSupply(10_000);
 
+    jest.advanceTimersByTime(10_000);
+
+    expect(supply.isOff?.error).toEqual(new Error('Timed out after 10000 ms'));
+  });
+  it('accepts custom supply instance', () => {
+
+    const supply = new Supply();
+
+    timedSupply(10_000, { supply });
     jest.advanceTimersByTime(10_000);
 
     expect(supply.isOff?.error).toEqual(new Error('Timed out after 10000 ms'));

--- a/src/timed-supply.spec.ts
+++ b/src/timed-supply.spec.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { SupplyIsOff } from './supply-is-off.js';
 import { timedSupply } from './timed-supply.js';
 
 describe('timedSupply', () => {
@@ -17,13 +18,15 @@ describe('timedSupply', () => {
 
     expect(supply.isOff?.error).toEqual(new Error('Timed out after 10000 ms'));
   });
-  it('cuts off the supply with custom reason after timeout', () => {
+  it('cuts off the supply with custom cut off indicator after timeout', () => {
 
-    const supply = timedSupply(10_000, { createReason: timeout => `Test timeout: ${timeout}` });
+    const supply = timedSupply(10_000, {
+      onTimeout: timeout => new SupplyIsOff({ result: `Test timeout: ${timeout}` }),
+    });
 
     jest.advanceTimersByTime(10_000);
 
-    expect(supply.isOff?.error).toBe('Test timeout: 10000');
+    expect(supply.isOff?.result).toBe('Test timeout: 10000');
   });
   it('can be cut off before the timeout', () => {
 

--- a/src/timed-supply.ts
+++ b/src/timed-supply.ts
@@ -1,28 +1,30 @@
+import { SupplyIsOff } from './supply-is-off.js';
 import { Supply } from './supply.js';
 
 /**
  * Creates a supply, that is automatically cut off after specified `timeout`.
  *
+ * @typeParam TResult - Supply result type.
  * @param timeout - The maximum time in milliseconds the supply exists for.
- * @param createReason - Creates a custom reason why the supply cut off after timeout. A timeout error used as reason
- * when omitted.
+ * @param onTimeout - Creates a custom indicator of supply cut off after timeout. A timeout error used as a failure
+ * reason when omitted.
  *
- * @returns New timed supply.
+ * @returns New timed supply. The timer will be stopped once this supply cut off.
  */
-export function timedSupply(
+export function timedSupply<TResult = void>(
     timeout: number,
     {
-      createReason = timedSupply$defaultReason,
+      onTimeout = timedSupply$defaultOnTimeout,
     }: {
-      readonly createReason?: ((this: void, timeout: number) => unknown) | undefined;
+      readonly onTimeout?: ((this: void, timeout: number) => SupplyIsOff<TResult>) | undefined;
     } = {},
-): Supply {
-  const supply = new Supply();
-  const handle = setTimeout(() => supply.off(createReason(timeout)), timeout);
+): Supply<TResult> {
+  const supply = new Supply<TResult>();
+  const handle = setTimeout(() => supply.cutOff(onTimeout(timeout)), timeout);
 
   return supply.whenOff(() => clearTimeout(handle));
 }
 
-function timedSupply$defaultReason(timeout: number): Error {
-  return new Error(`Timed out after ${timeout} ms`);
+function timedSupply$defaultOnTimeout<TResult>(timeout: number): SupplyIsOff<TResult> {
+  return new SupplyIsOff({ error: new Error(`Timed out after ${timeout} ms`) });
 }

--- a/src/timed-supply.ts
+++ b/src/timed-supply.ts
@@ -5,21 +5,24 @@ import { Supply } from './supply.js';
  * Creates a supply, that is automatically cut off after specified `timeout`.
  *
  * @typeParam TResult - Supply result type.
+ * @param supply - Custom timed supply instance. A new one will be constructed when omitted,
  * @param timeout - The maximum time in milliseconds the supply exists for.
  * @param onTimeout - Creates a custom indicator of supply cut off after timeout. A timeout error used as a failure
  * reason when omitted.
  *
- * @returns New timed supply. The timer will be stopped once this supply cut off.
+ * @returns Timed supply instance. The timer will be stopped once this supply cut off.
  */
 export function timedSupply<TResult = void>(
     timeout: number,
     {
+      supply = new Supply<TResult>(),
       onTimeout = timedSupply$defaultOnTimeout,
     }: {
+      readonly supply?: Supply<TResult>;
       readonly onTimeout?: ((this: void, timeout: number) => SupplyIsOff<TResult>) | undefined;
     } = {},
 ): Supply<TResult> {
-  const supply = new Supply<TResult>();
+
   const handle = setTimeout(() => supply.cutOff(onTimeout(timeout)), timeout);
 
   return supply.whenOff(() => clearTimeout(handle));


### PR DESCRIPTION
- feat: add supply result to `SupplyIsOff` indicator
- test: add missing `SupplyIsOff` initialization tests
- feat: add support for supply result
- feat: allow custom timeout indicator
- fix: stricter signature of `SupplyIn.off()` method
- feat(timed): accept custom supply instance
